### PR TITLE
Add missing allows_access_grant property to workflow template

### DIFF
--- a/config/workflows/default_workflow.json
+++ b/config/workflows/default_workflow.json
@@ -4,6 +4,7 @@
             "name": "default",
             "label": "Default workflow",
             "description": "A single submission step, default workflow",
+            "allows_access_grant": true,
             "actions": [
                 {
                     "name": "deposit",


### PR DESCRIPTION
This enables the default workflow should allow sharing and makes
our template comparable to what is generated in the recent version
of hyrax.
