### PR TITLE
Allows contact form email address to be set via an environment variable

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -4,7 +4,7 @@ Hyrax.config do |config|
   config.register_curation_concern :image
 
   # Email recipient of messages sent via the contact form
-  # config.contact_email = "repo-admin@example.org"
+  config.contact_email = Settings.contact_email
 
   # Text prefacing the subject entered in the contact form
   # config.subject_prefix = "Contact form:"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,5 @@
 # These settings can also be provided as environment variables, in the form, e.g.:
-#    SETTING__ACTIVE_JOB_QUEUE__URL=http://...
+#    SETTINGS__ACTIVE_JOB_QUEUE__URL=http://...
 #
 # The mapping is described in `./config/initializers/config.rb`.
 #
@@ -54,3 +54,5 @@ google_analytics_id:
 
 # Register here: http://www.geonames.org/manageaccount
 geonames_username: 'jcoyne'
+
+contact_email: ""


### PR DESCRIPTION
Fixes #1174 

Changes contact email config value to pull from settings.yml, allowing the value to be set via an environment variable. Also fixes the comment in settings.yml that indicates how to set values via an environment variable.

Note; I think this should work, but don't have a local environment set up that allows testing this change. Comments and testing are welcome.