### PR TITLE
Remove span from overridden view

### DIFF
--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -4,8 +4,6 @@
     <header>
       <%= render 'work_title', presenter: @presenter %>
     </header>
-
-    <span class="state state-<%= @presenter.workflow.state %>"><%= @presenter.workflow.state_label %></span>
   </div>
   <div class="col-sm-12">
     <div class="row">


### PR DESCRIPTION
It was already removed from the same template in Hyrax, which is overridden in Hyku. Without this change, the workflow label appears twice: once styled and once unstyled.

