### PR TITLE
Don't reference a missing constant

### DIFF
--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -1,6 +1,0 @@
-class TransfersController < ApplicationController
-  include Hyrax::TransfersControllerBehavior
-
-  # TODO: this should probably happen in hyrax
-  layout 'dashboard'
-end


### PR DESCRIPTION
This override is already happening upstream, so we have no need of this.
It's referencing a missing constant preventing deploys
