### PR TITLE
Add ability to add/remove/review Account Admins in SuperAdmin UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ gem 'rsolr', '~> 2.0'
 gem 'devise'
 gem 'devise-guests', '~> 0.3'
 gem 'devise-i18n'
+gem 'devise_invitable', '~> 1.6'
 
 gem 'apartment'
 gem 'config', '~> 1.2', '>= 1.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,9 @@ GEM
     devise-guests (0.6.0)
       devise
     devise-i18n (1.1.2)
+    devise_invitable (1.7.2)
+      actionmailer (>= 4.1.0)
+      devise (>= 4.0.0)
     diff-lcs (1.3)
     docile (1.1.5)
     dropbox-sdk (1.6.5)
@@ -859,6 +862,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.3)
   devise-i18n
+  devise_invitable (~> 1.6)
   factory_girl_rails
   fcrepo_wrapper (~> 0.4)
   flipflop (~> 2.3)

--- a/app/controllers/proprietor/accounts_controller.rb
+++ b/app/controllers/proprietor/accounts_controller.rb
@@ -14,7 +14,11 @@ module Proprietor
 
     # GET /accounts/1
     # GET /accounts/1.json
-    def show; end
+    def show
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.admin.sidebar.accounts'), proprietor_accounts_path
+      add_breadcrumb @account.tenant, edit_proprietor_account_path(@account)
+    end
 
     # GET /accounts/new
     def new
@@ -77,7 +81,8 @@ module Proprietor
 
       # Never trust parameters from the scary internet, only allow the white list through.
       def account_params
-        params.require(:account).permit(:name, :cname, :title, :admin_emails,
+        params.require(:account).permit(:name, :cname, :title,
+                                        admin_emails: [],
                                         solr_endpoint_attributes: [:id, :url],
                                         fcrepo_endpoint_attributes: [:id, :url, :base_path])
       end

--- a/app/controllers/proprietor/accounts_controller.rb
+++ b/app/controllers/proprietor/accounts_controller.rb
@@ -77,7 +77,7 @@ module Proprietor
 
       # Never trust parameters from the scary internet, only allow the white list through.
       def account_params
-        params.require(:account).permit(:name, :cname, :title,
+        params.require(:account).permit(:name, :cname, :title, :admin_emails,
                                         solr_endpoint_attributes: [:id, :url],
                                         fcrepo_endpoint_attributes: [:id, :url, :base_path])
       end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,4 +1,5 @@
 # Customer organization account
+# rubocop:disable Metrics/ClassLength
 class Account < ActiveRecord::Base
   # @param [String] piece the tenant piece of the canonical name
   # @return [String] full canonical name
@@ -95,24 +96,23 @@ class Account < ActiveRecord::Base
     RedisEndpoint.reset!
   end
 
-  # Get list of all administrator emails associated with this account
+  # Get all administrator emails associated with this account
   def admin_emails
     # Must ensure we are switched to proper tenant database
     Apartment::Tenant.switch(tenant) do
-      # return (comma separated) list of email addresses of all users with admin role on this site
-      User.with_role(:admin, Site.instance).map(&:email).join(', ')
+      # return list of email addresses of all users with admin role on this site
+      User.with_role(:admin, Site.instance).map(&:email)
     end
   end
 
   # Update administrator emails associated with this account
-  def admin_emails=(value)
-    emails = value.split(",").map(&:strip)
+  # @param [Array<String>] Array of emails
+  def admin_emails=(emails)
     # Must ensure we are switched to proper tenant database
     Apartment::Tenant.switch(tenant) do
       existing_admin_emails = User.with_role(:admin, Site.instance).map(&:email)
       new_admin_emails = emails - existing_admin_emails
       removed_admin_emails = existing_admin_emails - emails
-
       add_admins(new_admin_emails) if new_admin_emails
       remove_admins(removed_admin_emails) if removed_admin_emails
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -18,4 +18,44 @@ class Site < ActiveRecord::Base
       first_or_create
     end
   end
+
+  # Get all administrator emails associated with this site
+  def admin_emails
+    User.with_role(:admin, self).pluck(:email)
+  end
+
+  # Update administrator emails associated with this site
+  # @param [Array<String>] Array of user emails
+  def admin_emails=(emails)
+    existing_admin_emails = admin_emails
+    new_admin_emails = emails - existing_admin_emails
+    removed_admin_emails = existing_admin_emails - emails
+    add_admins_by_email(new_admin_emails) if new_admin_emails
+    remove_admins_by_email(removed_admin_emails) if removed_admin_emails
+  end
+
+  private
+
+    # Add/invite admins via email address
+    # @param [Array<String>] Array of user emails
+    def add_admins_by_email(emails)
+      # For users that already have accounts, add to role immediately
+      existing_emails = User.where(email: emails).map do |u|
+        u.add_role :admin, self
+        u.email
+      end
+      # For new users, send invitation and add to role
+      (emails - existing_emails).each do |email|
+        u = User.invite!(email: email)
+        u.add_role :admin, self
+      end
+    end
+
+    # Remove specific administrators
+    # @param [Array<String>] Array of user emails
+    def remove_admins_by_email(emails)
+      User.where(email: emails).find_each do |u|
+        u.remove_role :admin, self
+      end
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ActiveRecord::Base
   include Blacklight::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :invitable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
   before_create :add_default_roles

--- a/app/views/proprietor/accounts/edit.html.erb
+++ b/app/views/proprietor/accounts/edit.html.erb
@@ -1,14 +1,14 @@
 <% content_for :page_header do %>
-  <h1><span class="fa fa-gears"></span> Editing Account</h1>
+  <h1><span class="fa fa-gears"></span> <%= t(".header") %></h1>
 <% end %>
 
 <div class="row">
   <div class="col-md-12">
     <div class="panel panel-default account-form">
-      <%= form_for(@account, url: [:proprietor, @account], :html => { class: 'form' }) do |f| %>
+      <%= simple_form_for @account, url: [:proprietor, @account], html: { class: 'form' } do |f| %>
         <div class="panel-body">
           <% if @account.errors.any? %>
-            <div id="error_explanation">
+            <div id="error_explanation" class="alert alert-danger">
               <h2><%= pluralize(@account.errors.count, "error") %> prohibited this account from being saved:</h2>
               <ul>
                 <% @account.errors.messages.each do |key, messages| %>
@@ -18,47 +18,22 @@
             </div>
           <% end %>
 
-          <div class="form-group">
-            <%= f.label :tenant %><br>
-            <%= f.text_field :tenant, class: 'form-control', readonly: @account.persisted? %>
-          </div>
+          <%= f.input :tenant, readonly: @account.persisted? %>
+          <%= f.input :cname %>
 
-          <div class="form-group">
-            <%= f.label :cname %><br>
-            <%= f.text_field :cname, class: 'form-control' %>
-          </div>
-
-          <div class="form-group">
-            <%= f.label :admin_emails %><br>
-            <%= f.text_field :admin_emails, class: 'form-control' %>
-            <p class="help-block">(comma-separated list of email addresses)</p>
-          </div>
-
-          <%= f.fields_for :solr_endpoint do |s| %>
-            <h3>Solr Endpoint</h3>
-            <div class="form-group">
-              <%= s.label :url %><br>
-              <%= s.text_field :url, class: 'form-control' %>
-            </div>
+          <h3><%= t(".solr_endpoint") %></h3>
+          <%= f.simple_fields_for :solr_endpoint do |s| %>
+            <%= s.input :url %>
           <% end %>
 
+          <h3><%= t(".fcrepo_endpoint") %></h3>
           <%= f.fields_for :fcrepo_endpoint do |s| %>
-            <h3>Fcrepo Endpoint</h3>
-            <div class="form-group">
-              <%= s.label :url %><br>
-              <%= s.text_field :url, class: 'form-control' %>
-              <p class="help-block">(should not end with a slash)</p>
-            </div>
-            <div class="form-group">
-              <%= s.label :base_path %><br>
-              <%= s.text_field :base_path, class: 'form-control' %>
-              <p class="help-block">(should begin with a slash and not end with a slash)</p>
-            </div>
+            <%= s.input :url %>
+            <%= s.input :base_path %>
           <% end %>
 
-        </div>
-        <div class="panel-footer">
-          <%= f.submit class: 'btn btn-primary pull-right' %>
+          <%= f.submit class: 'btn btn-primary' %>
+          <%= link_to t('simple_form.cancel'), proprietor_accounts_path, class: 'btn btn-link action-cancel' %>
         </div>
       <% end %>
     </div>

--- a/app/views/proprietor/accounts/edit.html.erb
+++ b/app/views/proprietor/accounts/edit.html.erb
@@ -28,6 +28,12 @@
             <%= f.text_field :cname, class: 'form-control' %>
           </div>
 
+          <div class="form-group">
+            <%= f.label :admin_emails %><br>
+            <%= f.text_field :admin_emails, class: 'form-control' %>
+            <p class="help-block">(comma-separated list of email addresses)</p>
+          </div>
+
           <%= f.fields_for :solr_endpoint do |s| %>
             <h3>Solr Endpoint</h3>
             <div class="form-group">

--- a/app/views/proprietor/accounts/index.html.erb
+++ b/app/views/proprietor/accounts/index.html.erb
@@ -1,8 +1,8 @@
 <% content_for :page_header do %>
-  <h1><span class="fa fa-gears"></span> <%= t(:'hyrax.admin.sidebar.accounts') %></h1>
+  <h1><span class="fa fa-gears"></span> <%= t('.header') %></h1>
   <div class="pull-right">
     <%= link_to new_proprietor_account_path, class: 'btn btn-primary' do %>
-      <span class="fa fa-edit"></span> Create new account 
+      <span class="fa fa-edit"></span> <%= t('.create_new') %>
     <% end %>
   </div>
 <% end %>
@@ -14,9 +14,9 @@
         <table class="table table-striped datatable">
           <thead>
             <tr>
-              <th>Tenant</th>
-              <th>Cname</th>
-              <th>Actions</th>
+              <th><%= t('.tenant') %></th>
+              <th><%= t('.cname') %></th>
+              <th><%= t('.actions') %></th>
             </tr>
           </thead>
 
@@ -25,7 +25,7 @@
               <tr>
                 <td><%= account.tenant %></td>
                 <td><%= account.cname %></td>
-                <td class="col-md-1"><%= link_to 'Show', [:proprietor, account] %>&nbsp;<%= link_to 'Edit', [:edit, :proprietor, account] %>&nbsp;<%= link_to 'Destroy', [:proprietor, account], method: :delete, data: { confirm: 'Are you sure?' } %></td>
+                <td class="col-md-2"><%= link_to t('.manage'), [:proprietor, account] %>&nbsp;|&nbsp;<%= link_to t('helpers.action.edit'), [:edit, :proprietor, account] %>&nbsp;|&nbsp;<%= link_to t('helpers.action.delete'), [:proprietor, account], method: :delete, data: { confirm: t('.confirm_delete') } %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/proprietor/accounts/new.html.erb
+++ b/app/views/proprietor/accounts/new.html.erb
@@ -1,11 +1,11 @@
 <% content_for :page_header do %>
-  <h1><span class="fa fa-gears"></span> Create a new repository</h1>
+  <h1><span class="fa fa-gears"></span> <%= t('.header') %></h1>
 <% end %>
 
 <div class="row">
   <div class="col-md-12">
     <div class="panel panel-default account-form">
-      <%= form_for(@account, url: [:proprietor, @account], :html => { class: 'form form-horizontal' }) do |f| %>
+      <%= simple_form_for @account, url: [:proprietor, @account], html: { class: 'form' } do |f| %>
         <div class="panel-body">
             <% if @account.errors.any? %>
               <div id="error_explanation" class="alert alert-danger">
@@ -17,16 +17,11 @@
                 </ul>
               </div>
             <% end %>
-            <div class="form-group">
-              <%= f.label :name, 'Short name', class: 'col-md-2' %>
-              <div class="col-md-10">
-                <%= f.text_field :name, class: 'form-control' %>
-                <span class="help-block">A single or hyphenated name used for technical aspects of the repository (e.g., "acme" or "acme-library").</span>
-              </div>
-            </div>
-          </div>
-          <div class="panel-footer">
-            <%= f.submit class: 'btn btn-primary pull-right' %>
+
+            <%= f.input :name %>
+
+            <%= f.submit class: 'btn btn-primary' %>
+            <%= link_to t('simple_form.cancel'), proprietor_accounts_path, class: 'btn btn-link action-cancel' %>
           </div>
       <% end %>
     </div>

--- a/app/views/proprietor/accounts/show.html.erb
+++ b/app/views/proprietor/accounts/show.html.erb
@@ -1,14 +1,86 @@
-<p id="notice"><%= notice %></p>
+<% content_for :page_header do %>
+  <h1><span class="fa fa-gears"></span> <%= t('.header') %></h1>
+<% end %>
 
-<p>
-  <strong>Tenant:</strong>
-  <%= @account.tenant %>
-</p>
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="row">
+          <div class="col-sm-10">
+            <h2><%= @account.cname %></h2>
+          </div>
+          <div class="col-sm-2">
+            <div class="pull-right">
+              <%= link_to edit_proprietor_account_path(@account), class: 'btn btn-primary' do %>
+                <span class="fa fa-edit"></span> <%= t('.edit') %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="panel-body">
+        <%= simple_form_for @account, url: [:proprietor, @account], namespace: "add_form", html: { class: 'form' } do |f| %>
+          <div class="form-group">
+            <%= f.label :admin_emails, class: "control-label" %>
+            <%= f.hint :admin_emails %>
+            <%# Use input_field to support multiple :admin_emails fields that become an array of values %>
+            <%= f.input_field :admin_emails, multiple: true, class: "form-control", value: "" %>
+            <%# Add all existing admin emails as hidden inputs %>
+            <% @account.admin_emails.each do |email| %>
+                <%= f.input_field :admin_emails, multiple: true, hidden: true, value: email %>
+            <% end %>
+          </div>
+          <%= f.submit t('.add'), class: 'btn btn-primary' %>
+          <%= link_to t('simple_form.cancel'), proprietor_accounts_path, class: 'btn btn-link action-cancel' %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
 
-<p>
-  <strong>Cname:</strong>
-  <%= @account.cname %>
-</p>
-
-<%= link_to 'Edit', [:edit, :proprietor, @account] %> |
-<%= link_to 'Back', proprietor_accounts_path %>
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h2 class="panel-title display-page"><%= t('.current_admins.header') %></h2>
+      </div>
+      <div class="panel-body">
+        <table class="table table-striped">
+          <thead>
+            <th><%= t('.current_admins.email') %></th>
+            <th><%= t('.current_admins.actions') %></th>
+          </thead>
+          <tbody>
+            <% if @account.admin_emails.empty? %>
+              <tr>
+                <td><%= t('.current_admins.no_admins') %></td>
+                <td></td>
+              </tr>
+            <% else %>
+              <% @account.admin_emails.each do |email| %>
+                <tr>
+                  <td><%= email %></td>
+                  <td>
+                    <%# For the remove button form, add all admin emails *except this one* as hidden inputs %>
+                    <%= simple_form_for @account, url: [:proprietor, @account], namespace: "remove_#{email}_form", html: { class: 'form' } do |f| %>
+                      <% keep_emails = @account.admin_emails - [ email ] %>
+                      <% if keep_emails.empty? %>
+                        <%= f.input_field :admin_emails, multiple: true, hidden: true, value: '' %>
+                      <% else %>
+                        <% keep_emails.each do |keep_email| %>
+                          <%= f.input_field :admin_emails, multiple: true, hidden: true, value: keep_email %>
+                        <% end %>
+                      <% end %>
+                      <%= f.submit t('.remove'), class: 'btn btn-danger' %>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -107,6 +107,54 @@ Devise.setup do |config|
   # Send a notification email when the user's password is changed
   # config.send_password_change_notification = false
 
+  # ==> Configuration for :invitable
+  # The period the generated invitation token is valid, after
+  # this period, the invited resource won't be able to accept the invitation.
+  # When invite_for is 0 (the default), the invitation won't expire.
+  # config.invite_for = 2.weeks
+
+  # Number of invitations users can send.
+  # - If invitation_limit is nil, there is no limit for invitations, users can
+  # send unlimited invitations, invitation_limit column is not used.
+  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit n > 0, users can send n invitations.
+  # You can change invitation_limit column for some users so they can send more
+  # or less invitations, even with global invitation_limit = 0
+  # Default: nil
+  # config.invitation_limit = 5
+
+  # The key to be used to check existing users when sending an invitation
+  # and the regexp used to test it when validate_on_invite is not set.
+  # config.invite_key = {:email => /\A[^@]+@[^@]+\z/}
+  # config.invite_key = {:email => /\A[^@]+@[^@]+\z/, :username => nil}
+
+  # Flag that force a record to be valid before being actually invited
+  # Default: false
+  # config.validate_on_invite = true
+
+  # Resend invitation if user with invited status is invited again
+  # Default: true
+  # config.resend_invitation = false
+
+  # The class name of the inviting model. If this is nil,
+  # the #invited_by association is declared to be polymorphic.
+  # Default: nil
+  # config.invited_by_class_name = 'User'
+
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
+  # The column name used for counter_cache column. If this is nil,
+  # the #invited_by association is declared without counter_cache.
+  # Default: nil
+  # config.invited_by_counter_cache = :invitations_count
+
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: true
+  # config.allow_insecure_sign_in_after_accept = false
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -1,0 +1,31 @@
+en:
+  devise:
+    failure:
+      invited: "You have a pending invitation, accept it to finish creating your account."
+    invitations:
+      send_instructions: "An invitation email has been sent to %{email}."
+      invitation_token_invalid: "The invitation token provided is not valid!"
+      updated: "Your password was set successfully. You are now signed in."
+      updated_not_active: "Your password was set successfully."
+      no_invitations_remaining: "No invitations remaining"
+      invitation_removed: "Your invitation was removed."
+      new:
+        header: "Send invitation"
+        submit_button: "Send an invitation"
+      edit:
+        header: "Set your password"
+        submit_button: "Set my password"
+    mailer:
+      invitation_instructions:
+        subject: "Invitation instructions"
+        hello: "Hello %{email}"
+        someone_invited_you: "Someone has invited you to %{url}, you can accept it through the link below."
+        accept: "Accept invitation"
+        accept_until: "This invitation will be due in %{due_date}."
+        ignore: "If you don't want to accept the invitation, please ignore this email.<br />\nYour account won't be created until you access the link above and set your password."
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
+            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/config/locales/devise_invitable.es.yml
+++ b/config/locales/devise_invitable.es.yml
@@ -1,0 +1,31 @@
+es:
+  devise:
+    failure:
+      invited: "Tiene una invitación pendiente, aceptégala para terminar de crear su cuenta."
+    invitations:
+      send_instructions: "Se ha enviado un correo electrónico de invitación a %{email}."
+      invitation_token_invalid: "¡El símbolo de invitación proporcionado no es válido!"
+      updated: "Su contraseña se ha establecido correctamente. Ahora has iniciado sesión."
+      updated_not_active: "Su contraseña se ha establecido correctamente."
+      no_invitations_remaining: "No hay invitaciones restantes"
+      invitation_removed: "Su invitación se eliminó."
+      new:
+        header: "Enviar invitacion"
+        submit_button: "Enviar una invitación"
+      edit:
+        header: "Establece tu contraseña"
+        submit_button: "Establecer mi contraseña"
+    mailer:
+      invitation_instructions:
+        subject: "Instrucciones de invitación"
+        hello: "Hola %{email}"
+        someone_invited_you: "Alguien te ha invitado a %{url}, puedes aceptarlo a través del siguiente enlace."
+        accept: "Aceptar la invitacion"
+        accept_until: "Esta invitación será %{due_date}."
+        ignore: "Si no desea aceptar la invitación, ignore este correo electrónico.<br />\nSu cuenta no se creará hasta que acceda al enlace anterior y establezca su contraseña."
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
+            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/config/locales/devise_invitable.zh.yml
+++ b/config/locales/devise_invitable.zh.yml
@@ -1,0 +1,31 @@
+zh:
+  devise:
+    failure:
+      invited: "您有待处理的邀请，接受它以完成创建您的帐户。"
+    invitations:
+      send_instructions: "已发送邀请电子邮件 %{email}."
+      invitation_token_invalid: "提供的邀请令牌无效！"
+      updated: "您的密码设置成功。 您现在已经登录。"
+      updated_not_active: "您的密码设置成功。"
+      no_invitations_remaining: "没有邀请"
+      invitation_removed: "您的邀请已被删除。"
+      new:
+        header: "发送邀请"
+        submit_button: "发送邀请"
+      edit:
+        header: "设置你的密码"
+        submit_button: "设置我的密码"
+    mailer:
+      invitation_instructions:
+        subject: "邀请说明"
+        hello: "你好 %{email}"
+        someone_invited_you: "有人邀请你到 %{url}，您可以通过以下链接接受。"
+        accept: "接受邀请"
+        accept_until: "此邀请将到期 %{due_date}."
+        ignore: "如果您不想接受邀请，请忽略此电子邮件。<br />\n在您访问以上链接并设置密码之前，您的帐户将不会被创建。"
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
+            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,5 +134,15 @@ en:
         header: 'Editing Account'
         solr_endpoint: 'Solr Endpoint'
         fcrepo_endpoint: 'Fedora Endpoint'
+      show:
+        header: 'Manage Account'
+        edit: 'Edit Account'
+        add: 'Add'
+        remove: 'Remove'
+        current_admins:
+          header: 'Current Account Administrators'
+          email: 'Email'
+          actions: 'Actions'
+          no_admins: 'No administrators exist'
       new:
         header: 'Create a new repository'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,3 +121,18 @@ en:
         roles_and_permissions:        'Users and groups'
         system_status:                'System status'
         technical:                    'Technical'
+  proprietor:
+    accounts:
+      index:
+        header: 'Accounts'
+        create_new: 'Create new account'
+        tenant: 'Tenant (UUID)'
+        cname: 'CNAME'
+        manage: 'Manage'
+        confirm_delete: 'Are you sure you wish to delete this repository?'
+      edit:
+        header: 'Editing Account'
+        solr_endpoint: 'Solr Endpoint'
+        fcrepo_endpoint: 'Fedora Endpoint'
+      new:
+        header: 'Create a new repository'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,8 +141,8 @@ en:
         remove: 'Remove'
         current_admins:
           header: 'Current Account Administrators'
-          email: 'Email'
-          actions: 'Actions'
+          email: 'Email address'
+          actions: 'Action'
           no_admins: 'No administrators exist'
       new:
         header: 'Create a new repository'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -95,3 +95,28 @@ es:
         roles_and_permissions:        'Usarios y grupos'
         system_status:                'Estado del sistema'
         technical:                    'Técnico'
+  proprietor:
+    accounts:
+      index:
+        header: 'Cuentas'
+        create_new: 'Crear una nueva cuenta'
+        tenant: 'Inquilino (UUID)'
+        cname: 'CNAME'
+        manage: 'Gestionar'
+        confirm_delete: '¿Está seguro de que desea eliminar este repositorio?'
+      edit:
+        header: 'Editar cuenta'
+        solr_endpoint: 'Solr punto final'
+        fcrepo_endpoint: 'Fedora punto final'
+      show:
+        header: 'Administrar cuenta'
+        edit: 'Editar cuenta'
+        add: 'Añadir'
+        remove: 'Retirar'
+        current_admins:
+          header: 'Administradores de cuentas actuales'
+          email: 'Dirección de correo electrónico'
+          actions: 'Acción'
+          no_admins: 'No existen administradores'
+      new:
+        header: 'Crear un nuevo repositorio'

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -44,9 +44,9 @@ en:
       account:
         name: 'A single or hyphenated name used for technical aspects of the repository (e.g., "acme" or "acme-library").'
         fcrepo_endpoint:
-          url: 'Fedora URL hould not end with a slash'
+          url: 'Fedora URL should not end with a slash'
           base_path: 'Fedora base path should begin with a slash AND not end with a slash'
-        admin_emails: 'Please enter one email address at a time'
+        admin_emails: 'Enter one email address at a time'
       hyku_group:
         description: 'A brief summary of the role of the group'
     #   defaults:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -13,6 +13,15 @@ en:
       default_message: "Please review the problems below:"
     # Examples
     labels:
+      account:
+        name: 'Short name'
+        tenant: 'Tenant UUID'
+        cname: 'Tenant CNAME'
+        solr_endpoint:
+          url: 'URL'
+        fcrepo_endpoint:
+          url: 'URL'
+          base_path: 'Base Path'
       hyku_group:
         description: 'Description'
       group_search:
@@ -31,6 +40,11 @@ en:
     #     edit:
     #       email: 'E-mail.'
     hints:
+      account:
+        name: 'A single or hyphenated name used for technical aspects of the repository (e.g., "acme" or "acme-library").'
+        fcrepo_endpoint:
+          url: 'Fedora URL hould not end with a slash'
+          base_path: 'Fedora base path should begin with a slash AND not end with a slash'
       hyku_group:
         description: 'A brief summary of the role of the group'
     #   defaults:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -22,6 +22,7 @@ en:
         fcrepo_endpoint:
           url: 'URL'
           base_path: 'Base Path'
+        admin_emails: 'Add or invite new administrator (via email)'
       hyku_group:
         description: 'Description'
       group_search:
@@ -45,6 +46,7 @@ en:
         fcrepo_endpoint:
           url: 'Fedora URL hould not end with a slash'
           base_path: 'Fedora base path should begin with a slash AND not end with a slash'
+        admin_emails: 'Please enter one email address at a time'
       hyku_group:
         description: 'A brief summary of the role of the group'
     #   defaults:

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -9,6 +9,16 @@ es:
     error_notification:
       default_message: "Repase los problemas abajo, por favor:"
     labels:
+      account:
+        name: 'Nombre corto'
+        tenant: 'Inquilino UUID'
+        cname: 'Inquilino CNAME'
+        solr_endpoint:
+          url: 'URL'
+        fcrepo_endpoint:
+          url: 'URL'
+          base_path: 'Ruta base'
+        admin_emails: 'Agregar o invitar al nuevo administrador (por correo electrónico)'
       hyku_group:
         description: 'Descripción'
       group_search:
@@ -20,6 +30,12 @@ es:
       page_size:
         per: 'Mostrar'
     hints:
+      account:
+        name: 'Un nombre único o con guión utilizado para los aspectos técnicos del repositorio (por ejemplo, "acme" o "acme-library").'
+        fcrepo_endpoint:
+          url: 'La URL de Fedora no debe terminar con una barra'
+          base_path: 'Fedora base ruta debe comenzar con una barra y no terminar con una barra'
+        admin_emails: 'Introduce una dirección de correo electrónico a la vez'
       hyku_group:
         description: 'Un breve resumen de la función del grupo'
     placeholders:

--- a/config/locales/simple_form.zh.yml
+++ b/config/locales/simple_form.zh.yml
@@ -13,6 +13,16 @@ zh:
       default_message: "请查看以下问题："
     # Examples
     labels:
+      account:
+        name: '简称'
+        tenant: '承租人 UUID'
+        cname: '承租人 CNAME'
+        solr_endpoint:
+          url: '网址'
+        fcrepo_endpoint:
+          url: '网址'
+          base_path: '基本路径'
+        admin_emails: '添加或邀请新的管理员（通过电子邮件）'
       hyku_group:
         description: '描述'
       group_search:
@@ -31,6 +41,12 @@ zh:
     #     edit:
     #       email: 'E-mail.'
     hints:
+      account:
+        name: '用于存储库技术方面的单个或连字符名称（例如“acme”或“acme-library”）。'
+        fcrepo_endpoint:
+          url: 'Fedora 网址不应以斜线结尾'
+          base_path: 'Fedora 基本路径应以斜线开始，而不是以斜杠结尾'
+        admin_emails: '一次输入一个电子邮件地址'
       hyku_group:
         description: '小组角色的简要总结'
     #   defaults:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -120,3 +120,28 @@ zh:
         roles_and_permissions:        '用户和组'
         system_status:                '系统状态'
         technical:                    '技术'
+  proprietor:
+    accounts:
+      index:
+        header: '帐号'
+        create_new: '建立新帐户'
+        tenant: '承租人 (UUID)'
+        cname: 'CNAME'
+        manage: '管理'
+        confirm_delete: '您确定要删除此存储库吗？'
+      edit:
+        header: '编辑帐号'
+        solr_endpoint: 'Solr 端点'
+        fcrepo_endpoint: 'Fedora 端点'
+      show:
+        header: '管理帐户'
+        edit: '编辑帐号'
+        add: '加'
+        remove: '去掉'
+        current_admins:
+          header: '经常账户管理员'
+          email: '电子邮件地址'
+          actions: '行动'
+          no_admins: '没有管理员存在'
+      new:
+        header: '创建一个新的存储库'

--- a/db/migrate/20170605152346_devise_invitable_add_to_users.rb
+++ b/db/migrate/20170605152346_devise_invitable_add_to_users.rb
@@ -1,0 +1,12 @@
+class DeviseInvitableAddToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :invitation_token, :string
+    add_column :users, :invitation_created_at, :datetime
+    add_column :users, :invitation_sent_at, :datetime
+    add_column :users, :invitation_accepted_at, :datetime
+    add_column :users, :invitation_limit, :integer
+    add_column :users, :invited_by_id, :integer
+    add_column :users, :invited_by_type, :string
+    add_index :users, :invitation_token, :unique => true
+  end
+end

--- a/db/migrate/20170605152346_devise_invitable_add_to_users.rb
+++ b/db/migrate/20170605152346_devise_invitable_add_to_users.rb
@@ -7,6 +7,6 @@ class DeviseInvitableAddToUsers < ActiveRecord::Migration[5.0]
     add_column :users, :invitation_limit, :integer
     add_column :users, :invited_by_id, :integer
     add_column :users, :invited_by_type, :string
-    add_index :users, :invitation_token, :unique => true
+    add_index :users, :invitation_token, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170524170114) do
+ActiveRecord::Schema.define(version: 20170605152346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -164,8 +164,8 @@ ActiveRecord::Schema.define(version: 20170524170114) do
   end
 
   create_table "mailboxer_conversation_opt_outs", id: :serial, force: :cascade do |t|
-    t.integer "unsubscriber_id"
     t.string "unsubscriber_type"
+    t.integer "unsubscriber_id"
     t.integer "conversation_id"
     t.index ["conversation_id"], name: "index_mailboxer_conversation_opt_outs_on_conversation_id"
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
@@ -181,13 +181,13 @@ ActiveRecord::Schema.define(version: 20170524170114) do
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
-    t.integer "sender_id"
     t.string "sender_type"
+    t.integer "sender_id"
     t.integer "conversation_id"
     t.boolean "draft", default: false
     t.string "notification_code"
-    t.integer "notified_object_id"
     t.string "notified_object_type"
+    t.integer "notified_object_id"
     t.string "attachment"
     t.datetime "updated_at", null: false
     t.datetime "created_at", null: false
@@ -200,8 +200,8 @@ ActiveRecord::Schema.define(version: 20170524170114) do
   end
 
   create_table "mailboxer_receipts", id: :serial, force: :cascade do |t|
-    t.integer "receiver_id"
     t.string "receiver_type"
+    t.integer "receiver_id"
     t.integer "notification_id", null: false
     t.boolean "is_read", default: false
     t.boolean "trashed", default: false
@@ -285,8 +285,8 @@ ActiveRecord::Schema.define(version: 20170524170114) do
 
   create_table "roles", id: :serial, force: :cascade do |t|
     t.string "name"
-    t.integer "resource_id"
     t.string "resource_type"
+    t.integer "resource_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
@@ -558,7 +558,15 @@ ActiveRecord::Schema.define(version: 20170524170114) do
     t.string "arkivo_subscription"
     t.binary "zotero_token"
     t.string "zotero_userid"
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.integer "invited_by_id"
+    t.string "invited_by_type"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/spec/controllers/proprietor/accounts_controller_spec.rb
+++ b/spec/controllers/proprietor/accounts_controller_spec.rb
@@ -74,14 +74,19 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
       context "with valid params" do
         let(:new_attributes) do
           { cname: 'new.example.com',
-            fcrepo_endpoint_attributes: valid_fcrepo_endpoint_attributes }
+            fcrepo_endpoint_attributes: valid_fcrepo_endpoint_attributes,
+            admin_emails: ['test@test.com', 'me@myhouse.com'] }
         end
 
         it "updates the requested account" do
+          allow(Apartment::Tenant).to receive(:switch).with(account.tenant) do |&block|
+            block.call
+          end
           put :update, params: { id: account.to_param, account: new_attributes }
           account.reload
           expect(account.cname).to eq 'new.example.com'
           expect(account.fcrepo_endpoint.url).to eq 'http://127.0.0.1:8984/go'
+          expect(account.admin_emails).to match_array(['test@test.com', 'me@myhouse.com'])
           expect(response).to redirect_to([:proprietor, account])
         end
 

--- a/spec/features/accounts_spec.rb
+++ b/spec/features/accounts_spec.rb
@@ -9,12 +9,15 @@ RSpec.describe 'Accounts administration', multitenant: true do
     before do
       login_as(user, scope: :user)
       Capybara.default_host = "http://#{Account.admin_host}"
+      allow(Apartment::Tenant).to receive(:switch).with(account.tenant) do |&block|
+        block.call
+      end
     end
 
     it 'changes the associated cname' do
       visit edit_proprietor_account_path(account)
 
-      fill_in 'Cname', with: 'example.com'
+      fill_in 'Tenant CNAME', with: 'example.com'
 
       click_on 'Save'
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -230,4 +230,30 @@ RSpec.describe Account, type: :model do
       end
     end
   end
+
+  describe '#admin_emails' do
+    let!(:account) { FactoryGirl.create(:account, tenant: "mytenant") }
+    before do
+      Site.update(account: account)
+      Site.instance.admin_emails = ["test@test.com", "test@test.org"]
+    end
+    it 'switches to current tenant database and returns Site admin_emails' do
+      expect(Apartment::Tenant).to receive(:switch).with(account.tenant).and_yield
+      expect(account.admin_emails).to match_array(["test@test.com", "test@test.org"])
+    end
+  end
+
+  describe '#admin_emails=' do
+    let!(:account) { FactoryGirl.create(:account, tenant: "mytenant") }
+    before do
+      Site.update(account: account)
+      Site.instance.admin_emails = ["test@test.com", "test@test.org"]
+    end
+    it 'switches to current tenant database updates Site admin_emails' do
+      expect(Apartment::Tenant).to receive(:switch).with(account.tenant).exactly(3).times.and_yield
+      expect(account.admin_emails).to match_array(["test@test.com", "test@test.org"])
+      account.admin_emails = ["newadmin@here.org"]
+      expect(account.admin_emails).to match_array(["newadmin@here.org"])
+    end
+  end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,7 +1,55 @@
 RSpec.describe Site, type: :model do
+  let(:admin1) { FactoryGirl.create(:user, email: 'bob@was_here.net') }
+  let(:admin2) { FactoryGirl.create(:user, email: 'jane@was_here.net') }
+  let(:admin3) { FactoryGirl.create(:user, email: 'i@was_here.net') }
+
   describe ".instance" do
     it "is a singleton site" do
       expect(described_class.instance).to eq(described_class.instance)
+    end
+  end
+
+  describe ".admin_emails" do
+    subject { described_class.instance }
+    context "no admins exist" do
+      it "returns empty array" do
+        expect(subject.admin_emails).to eq([])
+      end
+    end
+    context "admins exist" do
+      before do
+        admin1.add_role :admin, subject
+        admin2.add_role :admin, subject
+      end
+      it "returns array of emails" do
+        expect(subject.admin_emails).to match_array([admin1.email, admin2.email])
+      end
+    end
+  end
+
+  describe ".admin_emails=" do
+    subject { described_class.instance }
+    context "passed empty array" do
+      before do
+        admin1.add_role :admin, subject
+        admin2.add_role :admin, subject
+      end
+      it "clears out all admins" do
+        expect(subject.admin_emails).to match_array([admin1.email, admin2.email])
+        subject.admin_emails = []
+        expect(subject.admin_emails).to eq([])
+      end
+    end
+    context "passed a new set of admins" do
+      before do
+        admin1.add_role :admin, subject
+        admin2.add_role :admin, subject
+      end
+      it "overwrites existing admins with new set" do
+        expect(subject.admin_emails).to match_array([admin1.email, admin2.email])
+        subject.admin_emails = [admin3.email, admin1.email]
+        expect(subject.admin_emails).to match_array([admin3.email, admin1.email])
+      end
     end
   end
 end

--- a/spec/views/proprietor/accounts/show.html.erb_spec.rb
+++ b/spec/views/proprietor/accounts/show.html.erb_spec.rb
@@ -1,13 +1,46 @@
 RSpec.describe "proprietor/accounts/show", type: :view do
   let(:account) { FactoryGirl.create(:account) }
+  let(:admin1) { build(:user) }
+  let(:admin2) { build(:user) }
 
   before do
+    allow(Apartment::Tenant).to receive(:switch).with(account.tenant) do |&block|
+      block.call
+    end
     @account = assign(:account, account)
   end
 
-  it "renders attributes in <p>" do
+  it "renders account admin management form" do
     render
-    expect(rendered).to include(account.tenant)
-    expect(rendered).to include(account.cname)
+    assert_select "form[action=?][method=?]", proprietor_account_path(account), "post" do
+      assert_select "input#add_form_account_admin_emails[name=?]", "account[admin_emails][]"
+    end
+  end
+
+  it 'has a button to edit account' do
+    render
+    expect(rendered).to have_css("a[class='btn btn-primary'] span[class='fa fa-edit']")
+  end
+
+  context 'with no admin users' do
+    before do
+      allow(account).to receive(:admin_emails).and_return([])
+      render
+    end
+    it 'displays "No administrators exist"' do
+      expect(rendered).to have_content('No administrators exist')
+    end
+  end
+
+  context 'with admin users' do
+    before do
+      allow(account).to receive(:admin_emails).and_return([admin1.email, admin2.email])
+      render
+    end
+    it 'displays each user email and a remove button' do
+      expect(rendered).to have_content(admin1.email)
+      expect(rendered).to have_content(admin2.email)
+      expect(rendered).to have_css("input[class='btn btn-danger'][value='Remove']")
+    end
   end
 end


### PR DESCRIPTION
Fixes #725 by enhancing the existing SuperAdmin UI (`/proprietor/accounts`) to provide the ability to easily add/remove/review Account Administrators.  Here's an example screenshot (for an account with cname="test3.lvh.me"):
![screenshot](https://user-images.githubusercontent.com/483997/26890630-da40e5ee-4b77-11e7-905e-105e84d3cbf6.png)

Adding a new Account Administrator uses `devise_invitable` to send an email invitation if the person does not yet have a login for that Account. If the person does have a login, then their login is immediately updated with Admin rights.

Also cleans up existing SuperAdmin UI screens to use `simple_form_for` and add i18n to all views.

**NOTE: This is flagged as a WIP, as it does not yet include updated specs or translations.**  However, the basic functionality is ready for review/comment, as it works.

@projecthydra-labs/hyrax-code-reviewers
