### PR TITLE
Disable account signup depending on Settings variable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,6 +65,10 @@ Rails/HasAndBelongsToMany:
 RSpec/AnyInstance:
   Enabled: false
 
+RSpec/InstanceVariable:
+  Exclude:
+    - 'spec/controllers/hyku/registrations_controller_spec.rb'
+
 RSpec/NamedSubject:
   Enabled: false
 

--- a/app/controllers/hyku/registrations_controller.rb
+++ b/app/controllers/hyku/registrations_controller.rb
@@ -1,0 +1,13 @@
+module Hyku
+  class RegistrationsController < Devise::RegistrationsController
+    def new
+      return super if Settings.devise.account_signup
+      redirect_to root_path, alert: t(:'hyku.account.signup_disabled')
+    end
+
+    def create
+      return super if Settings.devise.account_signup
+      redirect_to root_path, alert: t(:'hyku.account.signup_disabled')
+    end
+  end
+end

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,0 +1,30 @@
+<ul id="user_utility_links" class="nav navbar-nav navbar-right">
+  <%= render 'shared/locale_picker' if available_translations.size > 1 %>
+  <% if user_signed_in? %>
+    <li>
+      <%= render 'hyrax/users/notify_number' %>
+    </li>
+    <li class="dropdown">
+      <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false} do %>
+        <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
+        <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
+        <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
+        <span class="fa fa-user"></span>
+        <span class="caret"></span>
+      <% end %>
+      <ul class="dropdown-menu dropdown-menu-right" role="menu">
+        <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
+
+        <li class="divider"></li>
+        <li><%= link_to t("hyku.toolbar.profile.edit_registration"), main_app.edit_user_registration_path %></li>
+        <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
+      </ul>
+    </li><!-- /.btn-group -->
+  <% else %>
+    <li>
+      <%= link_to main_app.new_user_session_path do %>
+        <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> <%= t("hyrax.toolbar.profile.login") %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,11 @@ en:
     proprietor:
       accounts:
         nav: 'Accounts'
+    toolbar:
+      profile:
+        edit_registration: 'Change password'
+    account:
+      signup_disabled: 'Account registration is disabled'
     admin:
       title: 'Administration'
       flash:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -25,6 +25,11 @@ es:
       user_search:
         submit: 'Ir'
   hyku:
+    toolbar:
+      profile:
+        edit_registration: 'Cambia la contraseña'
+    account:
+      signup_disabled: 'El registro de la cuenta está deshabilitado'
     admin:
       title: 'Administración'
       flash:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -50,6 +50,11 @@ zh:
     proprietor:
       accounts:
         nav: '帐号'
+    toolbar:
+      profile:
+        edit_registration: '更改密码'
+    account:
+      signup_disabled: '帐户注册被禁用'
     admin:
       title: '行政'
       flash:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
 
   root 'hyrax/homepage#index'
 
-  devise_for :users
+  devise_for :users, controllers: { registrations: 'hyku/registrations' }
   mount Qa::Engine => '/authorities'
 
   mount Blacklight::Engine => '/'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,3 +56,6 @@ google_analytics_id:
 geonames_username: 'jcoyne'
 
 contact_email: ""
+
+devise:
+  account_signup: true

--- a/spec/controllers/hyku/registrations_controller_spec.rb
+++ b/spec/controllers/hyku/registrations_controller_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe Hyku::RegistrationsController, type: :controller do
+  before do
+    allow(Settings.devise).to receive(:account_signup).and_return(account_signup_enabled)
+    # Recommended by Devise: https://github.com/plataformatec/devise/wiki/How-To:-Test-controllers-with-Rails-3-and-4-%28and-RSpec%29
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  context 'with account signup enabled' do
+    let(:account_signup_enabled) { true }
+    describe '#new' do
+      it 'renders the form' do
+        get :new
+        expect(response).to render_template('devise/registrations/new')
+      end
+    end
+    describe '#create' do
+      it 'processes the form' do
+        post :create, params: {
+          user: {
+            email: "user@example.org",
+            password: "password",
+            password_confirmation: "password"
+          }
+        }
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en')
+        expect(flash[:notice]).to eq 'Welcome! You have signed up successfully.'
+      end
+    end
+  end
+  context 'with account signup disabled' do
+    let(:account_signup_enabled) { false }
+    describe '#new' do
+      it 'redirects with a flash message' do
+        get :new
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq 'Account registration is disabled'
+      end
+    end
+    describe '#create' do
+      it 'redirects with a flash message' do
+        post :create
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq 'Account registration is disabled'
+      end
+    end
+  end
+end

--- a/spec/views/_user_util_links.html.erb_spec.rb
+++ b/spec/views/_user_util_links.html.erb_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe '/_user_util_links.html.erb', type: :view do
+  let(:user) { create(:user) }
+  before do
+    allow(view).to receive(:user_signed_in?).and_return(true)
+    allow(view).to receive(:current_user).and_return(user)
+    render
+  end
+  it 'links to edit registration path' do
+    expect(rendered).to have_link 'Change password', href: edit_user_registration_path
+  end
+end


### PR DESCRIPTION
When account creation is disabled, redirect to the homepage with an alert. When enabled, let Devise do its thing. This implementation relies on a small routing change that lets Hyku override two methods in `Devise::RegistrationsController`.

Fixes #1203

@projecthydra-labs/hyrax-code-reviewers
