### PR TITLE
Move Solr container volume to where Solr data lives.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - 8983
     volumes:
       - .:/app
-      - solr:/data
+      - solr:/opt/solr/server/solr
     networks:
       internal:
 


### PR DESCRIPTION
Fixes #1246 
Moves mount point of the Solr Docker container's solr volume.

The Solr container saves its index data at `/opt/solr/server/solr`, instead of `/data` where the solr volume is mounted currently. Moving the index data to `/data` is not feasible because of volume permission issues, so keeping the data at its default location (and persisting it) is the simplest fix.

@projecthydra-labs/hyrax-code-reviewers
