### PR TITLE
Merge volume directives

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,13 +177,12 @@ services:
       - DOCKER_TLS_VERIFY
       - DOCKER_HOST
       - DOCKER_CERT_PATH
-    volumes:
-      - $DOCKER_CERT_PATH:$DOCKER_CERT_PATH
     ports:
       - 8080:80
       - 8443:443
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - $DOCKER_CERT_PATH:$DOCKER_CERT_PATH
     networks:
       internal:
       external:


### PR DESCRIPTION
Previously line 185 was overwriting line 180.
The volume previously on line 180 is critical for running on
docker-machine, but was not needed on Docker CE.
See https://hub.docker.com/r/dockercloud/haproxy/ "Running with Docker
Compose v2 (Compose Mode)"


@projecthydra-labs/hyrax-code-reviewers
