### PR TITLE
Load Hyku javascript assets before Hyrax ones, following a pattern found in ScholarSphere

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,11 +21,14 @@
 // Required by Blacklight
 //= require blacklight/blacklight
 
+// Moved the Hyku JS *above* the Hyrax JS to resolve #1187 (following
+// a pattern found in ScholarSphere)
+//
+//= require hyku/groups/per_page
+//= require hyku/groups/add_member
+
 //= require hyrax
 //= require jquery.flot.pie
 //= require flot_graph
 //= require statistics_tab_manager
 //= require blacklight_gallery/default
-
-//= require hyku/groups/per_page
-//= require hyku/groups/add_member


### PR DESCRIPTION
Fixes #1187
