### PR TITLE
Comment out DOCKER_CERT_PATH by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,7 +182,8 @@ services:
       - 8443:443
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - $DOCKER_CERT_PATH:$DOCKER_CERT_PATH
+      # You must uncomment this line if and only if you are running docker-machine
+      # - $DOCKER_CERT_PATH:$DOCKER_CERT_PATH
     networks:
       internal:
       external:


### PR DESCRIPTION
The current directions do not work on docker CE and cause the following error:
```
ERROR: for lb  Cannot create container for service lb: invalid volume spec ".": invalid volume specification: '.': invalid mount config for type "volume": invalid mount path: '.' mount path must be absolute
ERROR: Encountered errors while bringing up the project.
```