### PR TITLE
Use settings to configure a From address for user invitation email

### DIFF
--- a/app/mailers/hyrax/contact_mailer.rb
+++ b/app/mailers/hyrax/contact_mailer.rb
@@ -1,0 +1,13 @@
+module Hyrax
+  # Mailer for contacting the administrator
+  class ContactMailer < HykuMailer
+    def contact(contact_form)
+      @contact_form = contact_form
+      # Check for spam
+      return if @contact_form.spam?
+      headers = @contact_form.headers.dup
+      headers[:subject] << " [#{host_for_tenant}]"
+      mail(headers)
+    end
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = Settings.devise.invitation_from_email
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,7 +55,10 @@ google_analytics_id:
 # Register here: http://www.geonames.org/manageaccount
 geonames_username: 'jcoyne'
 
+# The address to which the contact form is submitted
 contact_email: ""
 
 devise:
   account_signup: true
+  # The address from which user invitations are sent
+  invitation_from_email: "change-me-in-hyku-settings@example.org"


### PR DESCRIPTION
Fixes #1265
    
See corresponding documentation here: https://github.com/samvera-labs/hyku/wiki/Set-email-addresses

Also, override Hyrax mailer to inject tenant name into contact form submissions.

Fixes #1230
