### PR TITLE
Only make iiif thumbnails for images.

### DIFF
--- a/app/services/iiif_thumbnail_path_service.rb
+++ b/app/services/iiif_thumbnail_path_service.rb
@@ -5,8 +5,15 @@ class IIIFThumbnailPathService < Hyrax::WorkThumbnailPathService
       # @param [FileSet] file_set
       # @param [String] size ('!150,300') an IIIF image size defaults to an image no
       #                      wider than 150px and no taller than 300px
-      # @return the IIIF url for the thumbnail.
+      # @return the IIIF url for the thumbnail if it's an image, otherwise gives
+      #         the thumbnail download path
       def thumbnail_path(file_set, size = '!150,300'.freeze)
+        return super(file_set) unless file_set.image?
+        iiif_thumbnail_path(file_set, size)
+      end
+
+      # @private
+      def iiif_thumbnail_path(file_set, size)
         file = file_set.original_file
         return unless file
         Riiif::Engine.routes.url_helpers.image_path(
@@ -19,4 +26,5 @@ class IIIFThumbnailPathService < Hyrax::WorkThumbnailPathService
         true
       end
   end
+  private_class_method :iiif_thumbnail_path
 end

--- a/spec/services/iiif_thumbnail_path_service_spec.rb
+++ b/spec/services/iiif_thumbnail_path_service_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe IIIFThumbnailPathService do
     double(id: 's1/78/4k/72/s1784k724/files/6185235a-79b2-4c29-8c24-4d6ad9b11470',
            mime_type: 'image/jpeg')
   end
+
   before do
     allow(ActiveFedora::Base).to receive(:find).with('s1784k724').and_return(file_set)
     allow(file_set).to receive_messages(original_file: file, id: 's1784k724')
@@ -12,17 +13,31 @@ RSpec.describe IIIFThumbnailPathService do
   end
 
   context "on a work" do
+    subject { described_class.call(work) }
+
     let(:work) { build(:generic_work, thumbnail_id: 's1784k724') }
+
     before do
       allow(work).to receive_messages(file_sets: [file_set])
     end
 
-    subject { described_class.call(work) }
     it { is_expected.to eq '/images/s1%2F78%2F4k%2F72%2Fs1784k724%2Ffiles%2F6185235a-79b2-4c29-8c24-4d6ad9b11470/full/!150,300/0/default.jpg' }
   end
 
   context "on a file set" do
     subject { described_class.call(file_set) }
-    it { is_expected.to eq '/images/s1%2F78%2F4k%2F72%2Fs1784k724%2Ffiles%2F6185235a-79b2-4c29-8c24-4d6ad9b11470/full/!150,300/0/default.jpg' }
+
+    context "with an image" do
+      it { is_expected.to eq '/images/s1%2F78%2F4k%2F72%2Fs1784k724%2Ffiles%2F6185235a-79b2-4c29-8c24-4d6ad9b11470/full/!150,300/0/default.jpg' }
+    end
+
+    context "with a pdf" do
+      let(:file) do
+        double(id: 's1/78/4k/72/s1784k724/files/6185235a-79b2-4c29-8c24-4d6ad9b11470',
+               mime_type: 'application/pdf')
+      end
+
+      it { is_expected.to eq '/downloads/s1784k724?file=thumbnail' }
+    end
   end
 end


### PR DESCRIPTION
Standard thumbnails for PDFs. This was needed because RIIIF doesn't
flatten pdfs, making them look all black. Similar to:
https://github.com/samvera/hydra-derivatives/issues/110



@projecthydra-labs/hyrax-code-reviewers
