### PR TITLE
Wrap viewer so height can be set without using viewer class.

### DIFF
--- a/app/assets/stylesheets/viewer.scss
+++ b/app/assets/stylesheets/viewer.scss
@@ -1,5 +1,9 @@
-.viewer {
+.viewer-wrapper {
   height: 500px;
+}
+
+.viewer {
+  height: 100%;
   padding: 10px;
   iframe {
     // position: absolute;

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,7 +1,7 @@
 <% if presenter.representative_id.present? %>
   <% if presenter.representative_presenter.image? %>
     <%= UniversalViewer.script_tag %>
-    <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter] %>"></div>
+    <div class="viewer-wrapper"><div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter] %>"></div></div>
   <% else %>
     <%= media_display presenter.representative_presenter %>
   <% end %>


### PR DESCRIPTION
Fixes #1251

Adds a wrapper class around viewer div so height can be set without using viewer class.

@projecthydra-labs/hyrax-code-reviewers
