### PR TITLE
Do not assume that everything has a thumbnail available.

### DIFF
--- a/app/services/concerns/iiif_thumbnail_paths.rb
+++ b/app/services/concerns/iiif_thumbnail_paths.rb
@@ -22,8 +22,13 @@ module IIIFThumbnailPaths
       )
     end
 
-    def thumbnail?(_thumbnail)
-      true
+    # @param [FileSet] thumbnail the object that is the thumbnail
+    # @return [boolean] true when a thumbnail (either generated or a common asset)
+    #                   is expected to be available on the file system
+    def thumbnail?(thumbnail)
+      return true if thumbnail.image? || thumbnail.pdf? || thumbnail.office_document? ||
+                     thumbnail.audio? || thumbnail.video?
+      super(thumbnail)
     end
   end
 end

--- a/spec/services/iiif_work_thumbnail_path_service_spec.rb
+++ b/spec/services/iiif_work_thumbnail_path_service_spec.rb
@@ -39,5 +39,14 @@ RSpec.describe IIIFWorkThumbnailPathService do
 
       it { is_expected.to eq '/downloads/s1784k724?file=thumbnail' }
     end
+
+    context "with an unsupported mime type" do
+      let(:file) do
+        double(id: 's1/78/4k/72/s1784k724/files/6185235a-79b2-4c29-8c24-4d6ad9b11470',
+               mime_type: 'text/example')
+      end
+
+      it { is_expected.to match %r{^\/assets\/work-\w+\.png$} }
+    end
   end
 end


### PR DESCRIPTION
Fixes samvera/hyrax#1095

Do not assume all files have thumbnails available.

IIIFThumbnailPaths assumes that a thumbnail derivative was created for all filesets, however derivative creation depends on the file file mime type being included in the list of supported mime types. Falling back on Hyrax in this case should display the default work icon in place of a thumbnail.

Changes proposed in this pull request:
* Use behavior from hyrax when `thumbnail?` is called on a fileset with an unsupported mime type.

@projecthydra-labs/hyrax-code-reviewers
