### PR TITLE
Turn off transcoding using ffmpeg

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -37,7 +37,7 @@ Hyrax.config do |config|
   # config.persistent_hostpath = 'http://localhost/files/'
 
   # If you have ffmpeg installed and want to transcode audio and video uncomment this line
-  # config.enable_ffmpeg = true
+  config.enable_ffmpeg = false
 
   # Using the database noid minter was too slow when ingesting 1000s of objects (8s per transaction),
   # so switching to UUIDs for the MVP.


### PR DESCRIPTION
Because we aren't installing ffmpeg on AWS/Docker.

Fixes #1141
Ref #1162

We should revert this when we install ffmpeg

@projecthydra-labs/hyrax-code-reviewers
