### PR TITLE
Don't let UV load a second copy of jquery

### DIFF
--- a/public/bower_includes/universalviewer/dist/uv-2.0.1/lib/embed.js
+++ b/public/bower_includes/universalviewer/dist/uv-2.0.1/lib/embed.js
@@ -167,7 +167,7 @@ docReady(function() {
             };
             document.getElementsByTagName("head")[0].appendChild(script);
         }
-    })(window, document, "1.10.2", function ($, scriptUri, absScriptUri, jqueryLoaded) {
+    })(window, document, "3.2.1", function ($, scriptUri, absScriptUri, jqueryLoaded) {
 
         $.support.cors = true;
 


### PR DESCRIPTION
Workaround for:
https://github.com/UniversalViewer/universalviewer/issues/471

This replacement will need to be repeated whenever we upgrade jquery


@projecthydra-labs/hyrax-code-reviewers
