### PR TITLE
Remove accidental definition of global #logger method

### DIFF
--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -12,13 +12,10 @@ Riiif::Image.info_service = lambda do |id, _file|
   { height: doc['height_is'], width: doc['width_is'] }
 end
 
-def logger
-  Rails.logger
-end
 
 Riiif::Image.file_resolver.id_to_uri = lambda do |id|
   ActiveFedora::Base.id_to_uri(CGI.unescape(id)).tap do |url|
-    logger.info "Riiif resolved #{id} to #{url}"
+    Rails.logger.info "Riiif resolved #{id} to #{url}"
   end
 end
 # Riiif::Image.file_resolver.basic_auth_credentials = [ActiveFedora.fedora.user, ActiveFedora.fedora.password]


### PR DESCRIPTION
This was definining a #logger method on the ruby top-level `main` object, globally available to all code anywhere, beyond this initializer.  (I verified indeed that happened)

I think this was unintentional (if you wanted to do such a thing, you wouldn't
do it here), and it's poor code hygiene. Opens you up to other bugs where
some other code somewhere else calls `logger` thinking it's getting something
else, but gets main#logger instead. Or calling `super` somewhere and getting this even weirder. 