### PR TITLE
Fix for #1171 - only include images in the IIIF Manifest

### DIFF
--- a/app/presenters/concerns/displays_image.rb
+++ b/app/presenters/concerns/displays_image.rb
@@ -3,8 +3,11 @@
 module DisplaysImage
   extend ActiveSupport::Concern
 
+  # Creates a display image only where FileSet is an image.
+  #
+  # @return [IIIFManifest::DisplayImage] the display image required by the manifest builder.
   def display_image
-    return nil unless FileSet.exists?(id)
+    return nil unless FileSet.exists?(id) && solr_document.image?
     # TODO: this is slow, find a better way (perhaps index iiif url):
     original_file = FileSet.find(id).original_file
 

--- a/spec/presenters/hyku/file_set_presenter_spec.rb
+++ b/spec/presenters/hyku/file_set_presenter_spec.rb
@@ -5,22 +5,35 @@ RSpec.describe Hyku::FileSetPresenter do
   let(:request) { double(base_url: 'http://test.host') }
   let(:presenter) { described_class.new(solr_document, nil, request) }
   let(:id) { CGI.escape(file_set.original_file.id) }
-  before do
-    Hydra::Works::AddFileToFileSet.call(file_set,
-                                        fixture_file('images/world.png'),
-                                        :original_file)
-  end
 
   describe "display_image" do
-    subject { presenter.display_image }
-    it "creates a display image" do
-      expect(subject).to be_instance_of IIIFManifest::DisplayImage
-      expect(subject.url).to eq "http://test.host/images/#{id}/full/600,/0/default.jpg"
+    context "when the file is not an image" do
+      subject { presenter.display_image }
+      before do
+        Hydra::Works::AddFileToFileSet.call(file_set,
+                                            fixture_file('csv/sample.csv'), :original_file)
+      end
+      it { is_expected.to be_nil }
+    end
+    context "when the file is an image" do
+      subject { presenter.display_image }
+      before do
+        Hydra::Works::AddFileToFileSet.call(file_set,
+                                            fixture_file('images/world.png'), :original_file)
+      end
+      it "creates a display image" do
+        expect(subject).to be_instance_of IIIFManifest::DisplayImage
+        expect(subject.url).to eq "http://test.host/images/#{id}/full/600,/0/default.jpg"
+      end
     end
   end
 
   describe "iiif_endpoint" do
     subject { presenter.send(:iiif_endpoint, file_set.original_file) }
+    before do
+      Hydra::Works::AddFileToFileSet.call(file_set,
+                                          fixture_file('images/world.png'), :original_file)
+    end
     it 'returns the url' do
       expect(subject.url).to eq "http://test.host/images/#{id}"
     end


### PR DESCRIPTION
Fixes #1171 

Only include images in the IIIF Manifest

At present, all FileSets are included in the IIIF Manifest. This creates RIIIF URLs that won't resolve when the files to which they refer are not images, and affects universal viewer as it can't render the content. The simple fix is to only include FileSets that contain image files in the manifest.

Changes proposed in this pull request:
*  Only return the an IIIFManifest::DisplayImage object when calling display_image where solr_document responds 'true' to solr_document.image?

@projecthydra-labs/hyrax-code-reviewers
