### PR TITLE
Carrierwave test flexibility

### DIFF
--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -17,11 +17,12 @@ RSpec.describe SitesController, type: :controller, singletenant: true do
 
     context "site with existing banner image" do
       before do
+        expect(BannerImageUploader).to receive(:storage).and_return(CarrierWave::Storage::File).at_least(3).times
         f = fixture_file_upload('/images/nypl-hydra-of-lerna.jpg', 'image/jpg')
         Site.instance.update(banner_image: f)
       end
 
-      it "deletes a banner image" do
+      it "#update with remove_banner_image deletes a banner image" do
         expect(Site.instance.banner_image?).to be true
         post :update, params: { id: Site.instance.id, remove_banner_image: 'Remove banner image' }
         expect(response).to redirect_to('/admin/appearance?locale=en')

--- a/spec/models/uploaded_file_spec.rb
+++ b/spec/models/uploaded_file_spec.rb
@@ -28,10 +28,8 @@ RSpec.describe 'Hyrax::UploadedFile' do # rubocop:disable RSpec/DescribeClass
     end
   end
 
-  describe CarrierWave::Storage::File do
-    it 'has default config' do
-      expect(config.storage).to eq described_class # in dev/test
-    end
+  describe CarrierWave::Storage::File do # default in dev/test
+    before { expect(Hyrax::UploadedFileUploader).to receive(:storage).and_return(described_class) }
     it_behaves_like 'Regular upload'
     it 'returns a SanitizedFile' do
       expect(upload.file.file).to be_a CarrierWave::SanitizedFile


### PR DESCRIPTION
Don't fail if run w/ live Settings.s3.upload_bucket.

This prevents tests from hardcoding the dev/test configuration and allows them to more accurately establish their expectations.  

This approach would help us test Carrierwave-AWS against live S3 configuration, which is a point of failure for us.