### PR TITLE
Add a rake task that runs other tasks on all or selected tenants

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -27,6 +27,11 @@ class Account < ActiveRecord::Base
     canonical_cname(host)
   end
 
+  def self.tenants(tenant_list)
+    return Account.all if tenant_list.blank?
+    where(cname: tenant_list)
+  end
+
   attr_readonly :tenant
   # name is unused after create, only used by sign_up/new forms
   validates :name,

--- a/lib/tasks/tenantize_task.rake
+++ b/lib/tasks/tenantize_task.rake
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/LineLength
 namespace :tenantize do
   desc 'Run given task on all or selected tenants'
   task :task, [:task_name] => :environment do |_cmd, args|
@@ -14,3 +15,4 @@ namespace :tenantize do
     end
   end
 end
+# rubocop:enable Metrics/LineLength

--- a/lib/tasks/tenantize_task.rake
+++ b/lib/tasks/tenantize_task.rake
@@ -1,0 +1,16 @@
+namespace :tenantize do
+  desc 'Run given task on all or selected tenants'
+  task :task, [:task_name] => :environment do |_cmd, args|
+    raise ArgumentError, 'A rake task name is required: `rake tenantize:task[do:the:thing,arg1,...]`' unless args.task_name.present?
+    raise ArgumentError, "Rake task not found: #{args.task_name}. Are you sure this task is defined?" unless Rake::Task.task_defined?(args.task_name)
+    tenant_list = ENV.fetch('tenants', '').split
+    Account.tenants(tenant_list).each do |account|
+      puts "Running '#{args.task_name}' task within '#{account.cname}' tenant"
+      account.switch do
+        Rake::Task[args.task_name].invoke(*args.extras)
+        # Re-enable the task or it won't be run the next iteration
+        Rake::Task[args.task_name].reenable
+      end
+    end
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,4 +1,25 @@
 RSpec.describe Account, type: :model do
+  describe '.tenants' do
+    context 'when tenant_list param is nil' do
+      it 'calls Account.all' do
+        expect(Account).to receive(:all)
+        described_class.tenants(nil)
+      end
+    end
+    context 'when tenant_list param is empty' do
+      it 'calls Account.all' do
+        expect(Account).to receive(:all)
+        described_class.tenants([])
+      end
+    end
+    context 'when tenant_list param is a string' do
+      it 'calls Account.where' do
+        expect(Account).to receive(:where).with(cname: 'foo bar baz')
+        described_class.tenants('foo bar baz')
+      end
+    end
+  end
+
   describe '.from_request' do
     let(:request) { double(host: 'example.com') }
     let(:noncanonical_request) { double(host: 'example.com.') }

--- a/spec/support/rake.rb
+++ b/spec/support/rake.rb
@@ -1,16 +1,11 @@
 require 'rake'
 
 module RakeHelper
-  def load_rake_environment(files)
-    @rake = Rake::Application.new
-    Rake.application = @rake
+  def run_task(task_name, *args)
     Rake::Task.define_task(:environment)
-    files.each { |file| load file }
-  end
-
-  def run_task(task, *args)
     capture_stdout_stderr do
-      @rake[task].invoke(*args)
+      Rake.application[task_name].reenable
+      Rake.application[task_name].invoke(*args)
     end
   end
 

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -1,12 +1,15 @@
 require 'rake'
 
 RSpec.describe "Rake tasks" do
+  before(:all) do
+    Rails.application.load_tasks
+  end
+
   describe "superadmin:grant" do
     let!(:user1) { FactoryGirl.create(:user) }
     let!(:user2) { FactoryGirl.create(:user) }
 
     before do
-      load_rake_environment [File.expand_path("../../../lib/tasks/grant_superadmin.rake", __FILE__)]
       user1.remove_role :superadmin
       user2.remove_role :superadmin
     end
@@ -29,6 +32,59 @@ RSpec.describe "Rake tasks" do
       run_task('superadmin:grant', user1.email, user2.email)
       expect(user1.has_role?(:superadmin)).to eq true
       expect(user2.has_role?(:superadmin)).to eq true
+    end
+  end
+
+  describe 'tenantize:task' do
+    # Creating full-fledged accounts because switching into a factory
+    # account leads to: One of the following schema(s) is invalid:
+    # "3af179cd-d433-43ab-9a53-23c38750cf45" "public"
+    # This is expensive.
+    before(:all) do
+      CreateAccount.new(Account.new(name: 'first')).save
+      CreateAccount.new(Account.new(name: 'second')).save
+    end
+    after(:all) do
+      Account.find_by(name: 'first').destroy
+      Account.find_by(name: 'second').destroy
+    end
+    before do
+      # This omits a tenant that appears automatically created and is not switch-intoable
+      allow(Account).to receive(:tenants).and_return(accounts)
+    end
+    let(:accounts) { Account.where(name: ['first', 'second']) }
+    let(:task) { double('task') }
+    it 'requires at least one argument' do
+      expect { run_task('tenantize:task') }.to raise_error(ArgumentError, /rake task name is required/)
+    end
+    it 'requires first argument to be a valid rake task' do
+      expect { run_task('tenantize:task', 'foobar') }.to raise_error(ArgumentError, /Rake task not found\: foobar/)
+    end
+    it 'runs against all tenants' do
+      accounts.each do |account|
+        expect(account).to receive(:switch).once.and_call_original
+      end
+      allow(Rake::Task).to receive(:[]).with('hyrax:count').and_return(task)
+      expect(task).to receive(:invoke).exactly(accounts.count).times
+      expect(task).to receive(:reenable).exactly(accounts.count).times
+      run_task('tenantize:task', 'hyrax:count')
+    end
+    context 'when run against specified tenants' do
+      let(:accounts) { [account] }
+      let(:account) { Account.find_by(name: 'first') }
+      before do
+        ENV['tenants'] = "garbage_value #{account.cname} other_garbage_value"
+      end
+      after do
+        ENV.delete('tenants')
+      end
+      it 'runs against a single tenant and ignores bogus tenants' do
+        expect(account).to receive(:switch).once.and_call_original
+        allow(Rake::Task).to receive(:[]).with('hyrax:count').and_return(task)
+        expect(task).to receive(:invoke).once
+        expect(task).to receive(:reenable).once
+        run_task('tenantize:task', 'hyrax:count')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #1357

To run the `rake user:list[email,foobar]` task within the context of all tenants, invoke `rake tenantize:task[user:list,email,foobar]`. To run the task only in specified tenants, use an environment variable named `tenants`, with each tenant cname separated by a space: `rake tenantize:task[user:list,email,foobar] tenants="foo.localhost baz.localhost quuuuux.localhost"`

@projecthydra-labs/hyrax-code-reviewers
