### PR TITLE
Ensure Site object in global scope is NilSite and never persisted.

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -68,6 +68,14 @@ class Account < ActiveRecord::Base
     end
   end
 
+  # @return [Boolean] whether this Account is the global tenant in a multitenant environment
+  def self.global_tenant?
+    # Global tenant only exists when multitenancy is enabled and NOT in test environment
+    # (In test environment tenant switching is currently not possible)
+    return false unless Settings.multitenancy.enabled && !Rails.env.test?
+    Apartment::Tenant.default_tenant == Apartment::Tenant.current
+  end
+
   def solr_endpoint
     super || NilSolrEndpoint.new
   end

--- a/app/models/nil_site.rb
+++ b/app/models/nil_site.rb
@@ -1,0 +1,35 @@
+# NilSite is used to represent the Site in the global tenant in a multitenant environment
+# (i.e. Sites only exist on individual tenants and never globally)
+class NilSite
+  class << self
+    # NilSite must be a singleton like Site
+    attr_writer :instance
+    def instance
+      @instance ||= NilSite.new
+    end
+  end
+
+  # Return nil for all these attributes
+  attr_reader :id, :account, :application_name, :institution_name,
+              :institution_name_full, :banner_image, :primary_key
+
+  def reload
+    NilSite.instance
+  end
+
+  def update(*)
+    false
+  end
+
+  def admin_emails
+    []
+  end
+
+  def admin_emails=(value)
+    value
+  end
+
+  def banner_image?
+    false
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -15,6 +15,7 @@ class Site < ActiveRecord::Base
              to: :instance
 
     def instance
+      return NilSite.instance if Account.global_tenant?
       first_or_create
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,6 @@ class User < ActiveRecord::Base
   private
 
     def add_default_roles
-      add_role :admin, Site.instance unless self.class.any?
+      add_role :admin, Site.instance unless self.class.any? || Account.global_tenant?
     end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -277,4 +277,26 @@ RSpec.describe Account, type: :model do
       expect(account.admin_emails).to match_array(["newadmin@here.org"])
     end
   end
+
+  describe '#global_tenant?' do
+    subject { described_class.global_tenant? }
+    context 'default setting for test environment' do
+      it { is_expected.to be false }
+    end
+    context 'single tenant in production environment' do
+      before do
+        allow(Settings.multitenancy).to receive(:enabled).and_return false
+        allow(Rails.env).to receive(:test?).and_return false
+      end
+      it { is_expected.to be false }
+    end
+    context 'default tenant in a multitenant production environment' do
+      before do
+        allow(Settings.multitenancy).to receive(:enabled).and_return true
+        allow(Rails.env).to receive(:test?).and_return false
+        allow(Apartment::Tenant).to receive(:current_tenant).and_return Apartment::Tenant.default_tenant
+      end
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/models/nil_site_spec.rb
+++ b/spec/models/nil_site_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe NilSite do
+  let(:instance) { described_class.instance }
+
+  describe "#instance" do
+    subject { described_class.instance }
+    # 'instance' should always return same obj (i.e. singleton)
+    it { is_expected.to be instance }
+  end
+
+  describe "#id" do
+    subject { instance.id }
+    it { is_expected.to be nil }
+  end
+
+  describe "#account" do
+    subject { instance.account }
+    it { is_expected.to be nil }
+  end
+
+  describe "#application_name" do
+    subject { instance.application_name }
+    it { is_expected.to be nil }
+  end
+
+  describe "#institution_name" do
+    subject { instance.institution_name }
+    it { is_expected.to be nil }
+  end
+
+  describe "#institution_name_full" do
+    subject { instance.institution_name_full }
+    it { is_expected.to be nil }
+  end
+
+  describe "#reload" do
+    subject { instance.reload }
+    it { is_expected.to be described_class.instance }
+  end
+
+  describe "#update" do
+    subject { instance.update(param: 'one') }
+    it { is_expected.to be false }
+  end
+
+  describe "#admin_emails" do
+    context "default value" do
+      subject { instance.admin_emails }
+      it { is_expected.to be_empty }
+    end
+    context "set a value" do
+      before { instance.admin_emails = "test@test.org" }
+      subject { instance.admin_emails }
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe "#admin_emails=" do
+    subject { instance.admin_emails = "one@two.org" }
+    it { is_expected.to eq("one@two.org") }
+  end
+
+  describe "#banner_image?" do
+    subject { instance.banner_image? }
+    it { is_expected.to be false }
+  end
+
+  describe "#banner_image" do
+    subject { instance.banner_image }
+    it { is_expected.to be nil }
+  end
+
+  describe "#primary_key" do
+    subject { instance.primary_key }
+    it { is_expected.to be nil }
+  end
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -4,8 +4,18 @@ RSpec.describe Site, type: :model do
   let(:admin3) { FactoryGirl.create(:user, email: 'i@was_here.net') }
 
   describe ".instance" do
-    it "is a singleton site" do
-      expect(described_class.instance).to eq(described_class.instance)
+    context "on global tenant" do
+      before do
+        allow(Account).to receive(:global_tenant?).and_return true
+      end
+      it "is a NilSite" do
+        expect(described_class.instance).to eq(NilSite.instance)
+      end
+    end
+    context "on a specific tenant" do
+      it "is a singleton site" do
+        expect(described_class.instance).to eq(described_class.instance)
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,15 @@
 RSpec.describe User, type: :model do
-  context 'the first created user' do
+  context 'the first created user in global tenant' do
+    subject { FactoryGirl.create(:base_user) }
+    before do
+      allow(Account).to receive(:global_tenant?).and_return true
+    end
+    it 'does not get the admin role' do
+      expect(subject).not_to have_role :admin
+    end
+  end
+
+  context 'the first created user on a tenant' do
     subject { FactoryGirl.create(:base_user) }
     it 'is given the admin role' do
       expect(subject).to have_role :admin, Site.instance


### PR DESCRIPTION
Fixes #1041

While this isn't a serious issue, it's extremely annoying/confusing to debugging other issues (see #1041). So, I'm scratching my own itch and simply fixing it.

This PR creates a new `NilSite` object which is used to represent the `Site` object in a global scope (i.e. global tenant in a multitenant environment). This `NilSite` ensures that an empty Site is not persisted to the database (and admin rights assigned) as described in #1041.

This PR comes with specs, but can also be tested by repeating the behavior described in #1041 and ensuring that an empty Site is not generated in the global / default database schema.

Comments/suggestions welcome, but this was the easiest way I could figure out to resolve this strange behavior.

@projecthydra-labs/hyrax-code-reviewers
