### PR TITLE
Create new admin_only_tenant_creation setting, default to true

### DIFF
--- a/app/controllers/account_sign_up_controller.rb
+++ b/app/controllers/account_sign_up_controller.rb
@@ -1,6 +1,8 @@
 class AccountSignUpController < ProprietorController
   load_and_authorize_resource instance_name: :account, class: 'Account'
 
+  before_action :ensure_admin!, if: :admin_only_tenant_creation?
+
   # GET /account/sign_up
   def new
     add_breadcrumb t(:'hyrax.controls.home'), root_path
@@ -22,6 +24,15 @@ class AccountSignUpController < ProprietorController
   end
 
   private
+
+    def ensure_admin!
+      # Require Admin access to perform any actions
+      authorize! :read, :admin_dashboard
+    end
+
+    def admin_only_tenant_creation?
+      Settings.multitenancy.admin_only_tenant_creation
+    end
 
     def first_user_registration_url
       new_user_registration_url(host: @account.cname)

--- a/app/views/splash/index.html.erb
+++ b/app/views/splash/index.html.erb
@@ -5,7 +5,13 @@
     <h1><%= application_name %></h1>
     <p><%= t('application.tagline') %></p>
     <p>
-      <%= link_to t('hyku.splash.account_signup'), account_sign_up_path, class: 'btn btn-lg btn-sign-up' %>
+      <% if !Settings.multitenancy.admin_only_tenant_creation || can?(:manage, Account) %>
+        <%= link_to t('hyku.splash.account_signup'), account_sign_up_path, class: 'btn btn-lg btn-sign-up' %>
+      <% elsif !user_signed_in? %>
+        <%= link_to t('hyku.splash.account_login'), main_app.new_user_session_path, class: 'btn btn-lg btn-sign-up' %>
+      <% else %>
+        <%= t('hyku.splash.account_denied') %>
+      <% end %>
     </p>
   </div>
 </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,8 @@ en:
         submit: 'Go'
   hyku:
     splash:
+      account_denied: You are not authorized to create tenants
+      account_login: Login to get started
       account_signup: Get Started
       left_heading: Easy
       left_text: Works for institutions large and small, from museums to university libraries. Get started in minutes.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,7 @@ multitenancy:
   enabled: false
   default_host: # "%{tenant}.dev"
   admin_host:
+  admin_only_tenant_creation: true
 
 ssl_configured: false
 

--- a/spec/features/splash_spec.rb
+++ b/spec/features/splash_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "The splash page", multitenant: true do
 
   it "shows the page, displaying the Hyku version" do
     visit '/'
-    expect(page).to have_link 'Get Started', href: account_sign_up_path(locale: 'en')
+    expect(page).to have_link 'Login to get started', href: main_app.new_user_session_path(locale: 'en')
 
     within 'footer' do
       expect(page).to have_link 'Administrator login'

--- a/spec/views/splash/index.html.erb_spec.rb
+++ b/spec/views/splash/index.html.erb_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+RSpec.describe "splash/index.html.erb", type: :view do
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  context 'Anonymous or non-Admin user with admin_only_tenant_creation=false' do
+    before do
+      allow(Settings.multitenancy).to receive(:admin_only_tenant_creation).and_return(false)
+      allow(controller).to receive(:can?).with(:manage, Account).and_return(false)
+      render
+    end
+    it "displays a 'Get Started' button" do
+      expect(page).to have_selector('a.btn-sign-up', text: 'Get Started')
+      assert_select "a.btn-sign-up[href=?]", account_sign_up_path
+    end
+  end
+
+  context 'Admin user with admin_only_tenant_creation=true' do
+    before do
+      allow(Settings.multitenancy).to receive(:admin_only_tenant_creation).and_return(true)
+      allow(controller).to receive(:can?).with(:manage, Account).and_return(true)
+      allow(controller).to receive(:user_signed_in?).and_return(true)
+      render
+    end
+    it "displays a 'Get Started' button" do
+      expect(page).to have_selector('a.btn-sign-up', text: 'Get Started')
+      assert_select "a.btn-sign-up[href=?]", account_sign_up_path
+    end
+  end
+
+  context 'Anonymous user with admin_only_tenant_creation=true' do
+    before do
+      allow(Settings.multitenancy).to receive(:admin_only_tenant_creation).and_return(true)
+      allow(controller).to receive(:can?).with(:manage, Account).and_return(false)
+      allow(controller).to receive(:user_signed_in?).and_return(false)
+      render
+    end
+    it "displays a 'Login to get started' button" do
+      expect(page).to have_selector('a.btn-sign-up', text: 'Login to get started')
+      assert_select "a.btn-sign-up[href=?]", main_app.new_user_session_path
+    end
+  end
+
+  context 'Authenticated, non-Admin user with admin_only_tenant_creation=true' do
+    before do
+      allow(Settings.multitenancy).to receive(:admin_only_tenant_creation).and_return(true)
+      allow(controller).to receive(:can?).with(:manage, Account).and_return(false)
+      allow(controller).to receive(:user_signed_in?).and_return(true)
+      render
+    end
+    it "displays a 'You are not authorized to create tenants' message" do
+      expect(page).to have_no_selector('a.btn-sign-up')
+      expect(page).to have_selector('p', text: 'You are not authorized to create tenants')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #735

Adds a new configuration `Settings.multitenancy.admin_only_tenant_creation` (default is true). When enabled, new tenants can only be created by logged in, superadmin users. When disabled, anonymous users can create new tenants & setup an account on that tenant (this scenario is mostly for demo purposes).

This results in two views of the splash page:
* If `admin_only_tenant_creation=false`, the splash page works like the existing demo site, and a big green "Get Started" button appears. In this scenario, anonymous users can create tenants.
* If  `admin_only_tenant_creation=true` (new default), the big green button will now say "Login to get started" and sends you to authenticate as a superadmin first. In this scenario, you must be a superadmin user to create tenants.
    * If you authenticate as a superadmin, the big green button will change back to the "Get Started" button, and you'll be able to create tenants.
    * If you authenticate as a non-superadmin, no button will appear, and instead you'll see a "You are not authorized to create tenants" message.

(Sidenote: I'm not sold on the config being named `admin_only_tenant_creation`, so if someone comes up with a shorter, descriptive name, let me know.)