### PR TITLE
Add/invite and delete tenant users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,22 @@
+module Admin
+  class UsersController < AdminController
+    before_action :load_user, only: [:destroy]
+
+    # NOTE: User creation/invitations handled by devise_invitable
+
+    # Delete a user from the site
+    def destroy
+      if @user.present? && @user.destroy
+        redirect_to hyrax.admin_users_path, notice: t('hyrax.admin.users.destroy.success', user: @user)
+      else
+        redirect_to hyrax.admin_users_path flash: { error: t('hyrax.admin.users.destroy.failure', user: @user) }
+      end
+    end
+
+    private
+
+      def load_user
+        @user = User.from_url_component(params[:id])
+      end
+  end
+end

--- a/app/controllers/hyku/invitations_controller.rb
+++ b/app/controllers/hyku/invitations_controller.rb
@@ -1,0 +1,9 @@
+module Hyku
+  class InvitationsController < Devise::InvitationsController
+    # For devise_invitable, specify post-invite path to be 'Manage Users' form
+    # (as the user invitation form is also on that page)
+    def after_invite_path_for(_resource)
+      hyrax.admin_users_path
+    end
+  end
+end

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -1,0 +1,71 @@
+<% provide :page_header do %>
+  <h1><span class="fa fa-user"></span> <%= t('hyrax.admin.users.index.title') %></h1>
+<% end %>
+
+<div class="panel panel-default users-invite">
+  <div class="panel-heading">
+      <%= t('.invite_users') %>
+  </div>
+  <div class="panel-body">
+      <%# user_invitation_path is provided by devise_invitable %>
+      <%= simple_form_for :user,  url: main_app.user_invitation_path, html: { class: 'form-inline pull-left' } do |f| %>
+        <div class="form-group">
+          <%= f.hint :email %>
+          <%= f.label :email, class: "control-label", required: false %>
+          <%= f.input_field :email, class: "form-control", value: "" %>
+          <%= f.submit t('.add'), class: 'btn btn-primary' %>
+        </div>
+      <% end %>
+  </div>
+</div>
+
+<div class="panel panel-default users-listing">
+  <div class="panel-heading">
+      <%= t('hyrax.admin.users.index.describe_users_html', count: @presenter.user_count) %>
+  </div>
+
+  <div class="panel-body">
+    <div class="table-responsive">
+      <table class="table table-striped datatable">
+        <thead>
+          <tr>
+            <th></th>
+            <th><%= t('.id_label') %></th>
+            <th><%= t('.role_label') %></th>
+            <th><%= t('.access_label') %></th>
+            <th><%= t('.status_label') %></th>
+            <th><%= t('.action_label') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @presenter.users.each do |user| %>
+            <tr>
+              <td><%= link_to hyrax.user_path(user) do %>
+                    <%= image_tag(user.avatar.url(:thumb), width: 30) if user.avatar.file %>
+                  <% end %>
+              </td>
+              <td><%= link_to user.email, hyrax.user_path(user) %></td>
+              <td><% roles = @presenter.user_roles(user) %>
+                  <ul><% roles.each do |role| %>
+                    <li><%= role %></li>
+                    <% end %>
+                  </ul>
+              </td>
+              <td>
+                <%# in the case that a user is created who never signs in, this is necessary %>
+                <relative-time datetime="<%= @presenter.last_accessed(user).getutc.iso8601 %>" title="<%= @presenter.last_accessed(user).to_formatted_s(:standard) %>">
+                  <%= @presenter.last_accessed(user).to_formatted_s(:long_ordinal) %>
+                </relative-time>
+              </td>
+              <%# If user accepted invite or was a self-signup, they are active. Otherwise pending %>
+              <td><%= user.accepted_or_not_invited? ? t('.status.active') : t('.status.pending') %></td>
+              <td>
+                <%= link_to t('.delete'),  main_app.admin_user_path(user), class: 'btn btn-danger btn-sm action-delete', method: :delete, data: { confirm: t('hyrax.admin.users.destroy.confirmation', user: user.email) } %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,6 +142,20 @@ en:
         roles_and_permissions:        'Users and groups'
         system_status:                'System status'
         technical:                    'Technical'
+      users:
+        index:
+          action_label: Action
+          add: Invite user
+          delete: Delete
+          invite_users: 'Add or Invite user via email'
+          status_label: Status
+          status:
+            active: Active
+            pending: Pending
+        destroy:
+          confirmation: 'Are you sure you wish to delete the user "%{user}"? This action is irreversible.'
+          success: 'User "%{user}" has been successfully deleted.'
+          failure: 'User "%{user}" could not be deleted.'
   proprietor:
     accounts:
       index:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -33,6 +33,8 @@ en:
         user_ids: 'User ID'
       page_size:
         per: 'Show'
+      user:
+        email: 'Email address'
     #   defaults:
     #     password: 'Password'
     #   user:
@@ -49,6 +51,8 @@ en:
         admin_emails: 'Enter one email address at a time'
       hyku_group:
         description: 'A brief summary of the role of the group'
+      user:
+        email: 'Enter one email address at a time. You may also resend an invitation via this form.'
     #   defaults:
     #     username: 'User name to sign in.'
     #     password: 'No special characters, please.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
 
   root 'hyrax/homepage#index'
 
-  devise_for :users, controllers: { registrations: 'hyku/registrations' }
+  devise_for :users, controllers: { invitations: 'hyku/invitations', registrations: 'hyku/registrations' }
   mount Qa::Engine => '/authorities'
 
   mount Blacklight::Engine => '/'
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resource :account, only: [:edit, :update]
+    resources :users, only: [:destroy]
     resources :groups do
       member do
         get :remove
@@ -74,5 +75,4 @@ Rails.application.routes.draw do
 
   mount Peek::Railtie => '/peek'
   mount Riiif::Engine => '/images', as: 'riiif'
-
 end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe Admin::UsersController, type: :controller do
+  context 'as an anonymous user' do
+    let(:user) { FactoryGirl.create(:user) }
+
+    describe 'DELETE #destroy' do
+      subject { User.find_by(id: user.id) }
+      before { delete :destroy, params: { id: user.id } }
+      it "doesn't delete the user and redirects to login" do
+        expect(subject).not_to be_nil
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+
+  context 'as an admin user' do
+    let(:user) { FactoryGirl.create(:user) }
+    before { sign_in create(:admin) }
+
+    describe 'DELETE #destroy' do
+      subject { User.find_by(id: user.id) }
+      before { delete :destroy, params: { id: user.to_param } }
+      it "deletes the user and displays success message" do
+        expect(subject).to be_nil
+        expect(flash[:notice]).to eq "User \"#{user.email}\" has been successfully deleted."
+      end
+    end
+  end
+end

--- a/spec/controllers/hyku/invitations_controller_spec.rb
+++ b/spec/controllers/hyku/invitations_controller_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe Hyku::InvitationsController, type: :controller do
+  describe '#after_invite_path_for' do
+    it "returns admin_users_path" do
+      expect(subject.after_invite_path_for(nil)).to eq Hyrax::Engine.routes.url_helpers.admin_users_path(locale: 'en')
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,5 +15,9 @@ FactoryGirl.define do
     factory :superadmin do
       after(:create) { |user| user.add_role(:superadmin) }
     end
+
+    factory :invited_user do
+      after(:create, &:invite!)
+    end
   end
 end

--- a/spec/views/hyrax/admin/users/index.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/users/index.html.erb_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe 'hyrax/admin/users/index.html.erb', type: :view do
+  let(:presenter) { Hyrax::Admin::UsersPresenter.new }
+  let(:users) { [] }
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  before do
+    # Create four normal user accounts
+    (1..4).each do |i|
+      users << FactoryGirl.create(:user,
+                                  display_name: "user#{i}",
+                                  email: "email#{i}@example.com",
+                                  last_sign_in_at: Time.zone.now - 15.minutes,
+                                  created_at: Time.zone.now - 3.days)
+    end
+    allow(presenter).to receive(:users).and_return(users)
+    assign(:presenter, presenter)
+    render
+  end
+
+  it "draws user invite form" do
+    expect(page).to have_selector("div.users-invite")
+    expect(page).to have_content("Add or Invite user via email")
+    expect(page).to have_selector("div.users-invite input.email")
+    expect(page).to have_selector("//input[@value='Invite user']")
+  end
+
+  it "draws user list with all users" do
+    expect(page).to have_selector("div.users-listing")
+    expect(page).to have_content("Username")
+    expect(page).to have_content("Roles")
+    expect(page).to have_content("Last access")
+    expect(page).to have_content("Status")
+    expect(page).to have_content("Action")
+
+    # All users should be listed & have status of active
+    (1..4).each do |i|
+      expect(page).to have_content("email#{i}@example.com")
+    end
+    expect(page).to have_selector("div.users-listing td", text: 'Active', count: 4)
+
+    # Delete button next to each user
+    expect(page).to have_selector('a', class: 'action-delete', count: 4)
+  end
+
+  context "with admin users" do
+    before do
+      # Create two admin acccounts
+      (5..6).each do |i|
+        users << FactoryGirl.create(:admin,
+                                    display_name: "admin-user#{i}",
+                                    email: "admin#{i}@example.com",
+                                    last_sign_in_at: Time.zone.now - 15.minutes,
+                                    created_at: Time.zone.now - 3.days)
+      end
+      render
+    end
+
+    it "lists users as having admin role" do
+      (5..6).each do |i|
+        expect(page).to have_content("admin#{i}@example.com")
+      end
+      expect(page).to have_selector("div.users-listing li", text: 'admin', count: 2)
+    end
+  end
+
+  context "with a user who hasn't accepted an invitation" do
+    before do
+      # Create one invited (pending) user
+      (7..7).each do |i|
+        users << FactoryGirl.create(:invited_user,
+                                    display_name: "invitee#{i}",
+                                    email: "invitee#{i}@example.com",
+                                    last_sign_in_at: Time.zone.now - 15.minutes,
+                                    created_at: Time.zone.now - 3.days)
+      end
+      render
+    end
+
+    it "lists one user as pending status, and others as active" do
+      (7..7).each do |i|
+        expect(page).to have_content("invitee#{i}@example.com")
+      end
+      expect(page).to have_selector("div.users-listing td", text: 'Pending', count: 1)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1204 and #1205

Overrides the default (Hyrax) "Manage Users" form to provide invitation functionality (via devise_invitable) and deletion functionality.

Below is an example screenshot of the updated form. The new features include:
* New invitation form above user listing (driven by devise_invitable)
* New "Action" column in user listing, providing deletion functionality
* "Username" column now includes an "(invitation pending)" note if the user has received an invitation but has not yet responded/accepted.

![screenshot](https://user-images.githubusercontent.com/483997/30492165-38d6e762-9a05-11e7-8622-24a611a3f399.png)

~~This PR is still a work-in-progress as it doesn't yet include specs. However, the code seems to work as tested. Therefore, early reviews of either the code or the UI/UX are welcome.~~ Now with specs!