### PR TITLE
Add metadata into IIIF Manifest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem 'zk'
 gem 'mods', '~> 2.1'
 gem 'riiif', '~> 1.1'
 
-gem 'iiif_manifest', '~> 0.2.0'
+gem 'iiif_manifest', '~> 0.3.0'
 
 group :aws, :test do
   gem 'carrierwave-aws'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,7 +404,7 @@ GEM
       activesupport (>= 3.2.18)
       faraday (>= 0.9)
       json
-    iiif_manifest (0.2.0)
+    iiif_manifest (0.3.0)
       activesupport (>= 4)
       iiif-presentation (~> 0.2.0)
     inflecto (0.0.2)
@@ -898,7 +898,7 @@ DEPENDENCIES
   hyrax!
   i18n-debug
   i18n-tasks
-  iiif_manifest (~> 0.2.0)
+  iiif_manifest (~> 0.3.0)
   is_it_working
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -8,32 +8,37 @@ module Hyku
       manifest_helper.polymorphic_url([:manifest, self])
     end
 
-    # Hash to populate IIIF manifest with extras. Currently only sequence rendering is implemented.
+    # IIIF rendering linking property for inclusion in the manifest
     #
-    # @return [Hash] hash including sequence_rendering
-    def manifest_extras
-      {
-        sequence_rendering: sequence_rendering
-      }
+    # @return [Array] array of rendering hashes
+    def sequence_rendering
+      renderings = []
+      if solr_document.rendering_ids.present?
+        solr_document.rendering_ids.each do |file_set_id|
+          renderings << build_rendering(file_set_id)
+        end
+      end
+      renderings.flatten
+    end
+
+    # IIIF metadata for inclusion in the manifest
+    #
+    # @return [Array] array of metadata hashes
+    def manifest_metadata
+      metadata = []
+      metadata_fields.each do |field|
+        metadata << {
+          'label' => field.to_s.humanize.capitalize,
+          'value' => get_metadata_value(field)
+        }
+      end
+      metadata
     end
 
     private
 
       def manifest_helper
         @manifest_helper ||= ManifestHelper.new(request.base_url)
-      end
-
-      # IIIF rendering linking property for inclusion in the manifest
-      #
-      # @return [Array] array of rendering hashes
-      def sequence_rendering
-        renderings = []
-        if solr_document.rendering_ids.present?
-          solr_document.rendering_ids.each do |file_set_id|
-            renderings << build_rendering(file_set_id)
-          end
-        end
-        renderings.flatten
       end
 
       # Build a rendering hash
@@ -57,6 +62,27 @@ module Hyku
         ActiveFedora::SolrService.query("id:#{file_set_id}",
                                         fl: [ActiveFedora.id_field, 'label_ssi', 'mime_type_ssi'],
                                         rows: 1)
+      end
+
+      # Retrieve the required fields from the Form class. Derive the Form class name from the Model name.
+      #   The class should exist, but it may not if different namespaces are being used.
+      #   If it does not exist, rescue and return an empty Array.
+      #
+      # @return [Array] required fields
+      def metadata_fields
+        ns = "Hyrax"
+        model = solr_document['has_model_ssim'].first
+
+        "#{ns}::#{model}Form".constantize.required_fields
+      rescue
+        []
+      end
+
+      # Get the metadata value(s).
+      #
+      # @return [Array] field value(s)
+      def get_metadata_value(field)
+        Array.wrap(send(field))
       end
   end
 end

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -59,32 +59,31 @@
 
   <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>    
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
     <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
-    
+
     <!-- Default numeric field types.  -->
     <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
-    
+
     <!-- trie numeric field types for faster range queries -->
     <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0"/>
-    
+
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
       -->
     <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
     <!-- A Trie based date field for faster date range queries and date faceting. -->
     <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
-    
-    
+
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if 
+      definition is created matching *___<typename>.  Alternately, if
       subFieldSuffix is defined, that is used to create the subFields.
       Example: if subFieldType="double", then the coordinates would be
         indexed in fields myloc_0___double,myloc_1___double.
@@ -94,17 +93,17 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-    
+
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
-    
+
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:
       http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
     -->
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
       geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
-    
+
     <fieldType name="text" class="solr.TextField" omitNorms="false">
       <analyzer>
         <tokenizer class="solr.ICUTokenizerFactory"/>
@@ -112,7 +111,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- A text field that only splits on whitespace for exact matching of words -->
     <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -120,7 +119,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-        
+
     <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
     <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
       <analyzer>
@@ -129,7 +128,7 @@
         <filter class="solr.TrimFilterFactory" />
       </analyzer>
     </fieldtype>
-    
+
     <!-- A text field with defaults appropriate for English -->
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -144,7 +143,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-        
+
     <!-- queries for paths match documents at that path, or in descendent paths -->
     <fieldType name="descendent_path" class="solr.TextField">
       <analyzer type="index">
@@ -154,7 +153,7 @@
         <tokenizer class="solr.KeywordTokenizerFactory" />
       </analyzer>
     </fieldType>
-    
+
     <!-- queries for paths match documents at that path, or in ancestor paths -->
     <fieldType name="ancestor_path" class="solr.TextField">
       <analyzer type="index">
@@ -175,16 +174,15 @@
     </fieldType>
   </types>
 
-
   <fields>
     <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
     or Solr won't start. _version_ and update log are required for SolrCloud
-    --> 
+    -->
     <field name="_version_" type="long" indexed="true" stored="true"/>
-   
+
     <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
-    
+
     <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>
 
@@ -201,7 +199,7 @@
     <dynamicField name="*_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsiv" type="text" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsimv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-    
+
     <!-- English text (_te...) -->
     <dynamicField name="*_tei" type="text_en" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_teim" type="text_en" stored="false" indexed="true" multiValued="true"/>
@@ -213,7 +211,7 @@
     <dynamicField name="*_teimv" type="text_en" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tesiv" type="text_en" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tesimv" type="text_en" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-    
+
     <!-- string (_s...) -->
     <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true"/>
@@ -222,7 +220,7 @@
     <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true" multiValued="false"/>
-    
+
     <!-- integer (_i...) -->
     <dynamicField name="*_ii" type="int" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_iim" type="int" stored="false" indexed="true" multiValued="true"/>
@@ -230,7 +228,7 @@
     <dynamicField name="*_ism" type="int" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_isi" type="int" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_isim" type="int" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie integer (_it...) (for faster range queries) -->
     <dynamicField name="*_iti" type="tint" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_itim" type="tint" stored="false" indexed="true" multiValued="true"/>
@@ -238,7 +236,7 @@
     <dynamicField name="*_itsm" type="tint" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_itsi" type="tint" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_itsim" type="tint" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- date (_dt...) -->
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z -->
@@ -248,7 +246,7 @@
     <dynamicField name="*_dtsm" type="date" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dtsi" type="date" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dtsim" type="date" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie date (_dtt...) (for faster range queries) -->
     <dynamicField name="*_dtti" type="tdate" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dttim" type="tdate" stored="false" indexed="true" multiValued="true"/>
@@ -256,7 +254,7 @@
     <dynamicField name="*_dttsm" type="tdate" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dttsi" type="tdate" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dttsim" type="tdate" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- long (_l...) -->
     <dynamicField name="*_li" type="long" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_lim" type="long" stored="false" indexed="true" multiValued="true"/>
@@ -264,7 +262,7 @@
     <dynamicField name="*_lsm" type="long" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_lsi" type="long" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_lsim" type="long" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie long (_lt...) (for faster range queries) -->
     <dynamicField name="*_lti" type="tlong" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_ltim" type="tlong" stored="false" indexed="true" multiValued="true"/>
@@ -272,7 +270,7 @@
     <dynamicField name="*_ltsm" type="tlong" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_ltsi" type="tlong" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ltsim" type="tlong" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- double (_db...) -->
     <dynamicField name="*_dbi" type="double" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbim" type="double" stored="false" indexed="true" multiValued="true"/>
@@ -280,7 +278,7 @@
     <dynamicField name="*_dbsm" type="double" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dbsi" type="double" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbsim" type="double" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie double (_dbt...) (for faster range queries) -->
     <dynamicField name="*_dbti" type="tdouble" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbtim" type="tdouble" stored="false" indexed="true" multiValued="true"/>
@@ -288,7 +286,7 @@
     <dynamicField name="*_dbtsm" type="tdouble" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dbtsi" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbtsim" type="tdouble" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- float (_f...) -->
     <dynamicField name="*_fi" type="float" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_fim" type="float" stored="false" indexed="true" multiValued="true"/>
@@ -296,7 +294,7 @@
     <dynamicField name="*_fsm" type="float" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_fsi" type="float" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_fsim" type="float" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie float (_ft...) (for faster range queries) -->
     <dynamicField name="*_fti" type="tfloat" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_ftim" type="tfloat" stored="false" indexed="true" multiValued="true"/>
@@ -304,12 +302,12 @@
     <dynamicField name="*_ftsm" type="tfloat" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_ftsi" type="tfloat" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ftsim" type="tfloat" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- boolean (_b...) -->
     <dynamicField name="*_bi" type="boolean" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_bs" type="boolean" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="false"/>
-    
+
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
     <dynamicField name="*_coordinate" type="tdouble" indexed="true"  stored="false" />
 
@@ -326,19 +324,12 @@
     <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
     <field name="all_text_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
 
-
   </fields>
 
- <!-- Field to use to determine and enforce document uniqueness. 
+ <!-- Field to use to determine and enforce document uniqueness.
       Unless this field is marked with required="false", it will be a required field
    -->
  <uniqueKey>id</uniqueKey>
-
- <!-- field for the QueryParser to use when an explicit fieldname is absent -->
- <!--  <defaultSearchField>text</defaultSearchField> -->
-
- <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
 
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,

--- a/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
+++ b/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
 
   describe "#manifest_url" do
     subject { presenter.manifest_url }
+
     let(:document) { { "has_model_ssim" => ['GenericWork'], 'id' => '99' } }
+
     it { is_expected.to eq 'http://test.host/concern/generic_works/99/manifest' }
   end
 
@@ -25,9 +27,9 @@ RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
     end
   end
 
-  describe "manifest_extras" do
+  describe "#sequence rendering" do
     subject do
-      presenter.manifest_extras
+      presenter.sequence_rendering
     end
 
     before do
@@ -37,7 +39,22 @@ RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
 
     it "returns a hash containing the rendering information" do
       work.rendering_ids = [work.file_sets.first.id]
-      expect(subject).to include(:sequence_rendering)
+      expect(subject).to be_an Array
+    end
+  end
+
+  describe "#manifest metadata" do
+    subject do
+      presenter.manifest_metadata
+    end
+
+    before do
+      work.title = ['Test title', 'Another test title']
+    end
+
+    it "returns an array of metadata values" do
+      expect(subject[0]['label']).to eq('Title')
+      expect(subject[0]['value']).to include('Test title', 'Another test title')
     end
   end
 end


### PR DESCRIPTION
The IIIF Presentation API supports adding arbitrary metadata within a `metadata` array.

This small change in Hyku add a manifest_metadata method into ManifestEnabledWorkShowPresenter to support adding metadata into the IIIF manifest. It takes the `required_fields` for the object and returns a metadata array. This method is then consumed by the `iiif_manifest` gem (via this [PR](https://github.com/samvera-labs/iiif_manifest/pull/9)) and the metadata is added to the manifest. In Universal Viewer, the metadata will be displayed in the **_More Information_** tab to the right.

![image](https://user-images.githubusercontent.com/722117/30744776-8c43372a-9f9b-11e7-90c4-0b03b3cdbb88.png)

The mechanism for getting the required fields is a bit brittle and wouldn't work with works generated with a namespace. Having said that, it does not error, it just means metadata won't be retrieved by the `manifest_metadata` method if the Form class is not in the format `Hyrax::MyModelForm`.

In addition, there is a small change to `sequence_rendering` to simplify the implementation and align it with the current implementation of `iiif_manifest`.

`Gemfile` and `Gemfile.lock` updated to use `iiif_manifest` 0.3.0 which includes support for these new features.

@projecthydra-labs/hyrax-code-reviewers
