### PR TITLE
Fixes honeybadger deployment notification

### DIFF
--- a/.ebextensions/honeybadger.config
+++ b/.ebextensions/honeybadger.config
@@ -6,9 +6,9 @@ files:
     content: |
       #!/usr/bin/env bash
 
-      EB_CONFIG_SOURCE_BUNDLE=$(/opt/elasticbeanstalk/bin/get-config container -k source_bundle)
-      EB_SUPPORT_FILES=$(/opt/elasticbeanstalk/bin/get-config container -k support_files_dir)
+      EB_SUPPORT_DIR=$(/opt/elasticbeanstalk/bin/get-config container -k support_dir)
 
-      DEPLOY_ENVS=$($EB_SUPPORT_FILES/generate_env | grep "APP_ENV\|HONEYBADGER_API_KEY")
+      . $EB_SUPPORT_DIR/envvars
 
-      /usr/bin/env $DEPLOY_ENVS APP_VERSION=$(unzip -z "${EB_CONFIG_SOURCE_BUNDLE}" | tail -n 1) bash -c 'curl -sd "deploy[repository]=git@github.com:projecthydra-labs/hyku.git&deploy[revision]=${APP_VERSION}&deploy[local_username]=root&deploy[environment]=${APP_ENV}&api_key=${HONEYBADGER_API_KEY}" https://api.honeybadger.io/v1/deploys' > /tmp/deploy_01_notify.log
+      APP_VERSION=$(cat /opt/elasticbeanstalk/deploy/manifest | egrep -o "[0-9a-f]{40} | uniq")
+      curl -sd "deploy[repository]=git@github.com:${GITHUB_REPO}&deploy[revision]=${APP_VERSION}&deploy[local_username]=root&deploy[environment]=${HONEYBADGER_ENV}&api_key=${HONEYBADGER_API_KEY}" https://api.honeybadger.io/v1/deploys > /tmp/deploy_01_notify.log


### PR DESCRIPTION
The honeybadger deployment notification script was breaking deploys to the stanford demo stack. This fixes that.

This adds the need for another environment variable of `GITHUB_REPO` at the beanstalk environment to work properly. I made an issue to track that work: https://github.com/hybox/aws/issues/169

@samvera/hyrax-code-reviewers
