### PR TITLE
Monkey-patch config gem per railsconfig/config#180

### DIFF
--- a/config/initializers/config_monkeypatch.rb
+++ b/config/initializers/config_monkeypatch.rb
@@ -1,0 +1,26 @@
+# Monkey-patch config gem to support Boolean values in environment variable overrides
+# This monkey-patch can be removed once this ticket is fixed & a new version of 'config'
+# gem is released: https://github.com/railsconfig/config/issues/178
+Config::Options.class_eval do
+  protected
+
+    # Try to convert string to a correct type
+    # monkey-patch this method to support boolean conversion:
+    # https://github.com/railsconfig/config/blob/master/lib/config/options.rb#L190
+    def __value(v)
+      # rubocop:disable Style/RescueModifier
+      __boolean(v) rescue Integer(v) rescue Float(v) rescue v
+      # rubocop:enable Style/RescueModifier
+    end
+
+    def __boolean(value)
+      case value
+      when 'false'
+        false
+      when 'true'
+        true
+      else
+        raise ArgumentError, "invalid value for Boolean(): #{v.inspect}"
+      end
+    end
+end


### PR DESCRIPTION
Fixes #1462 

This PR monkey patches the `config` gem, based on @mjgiarlo's bug fix PR to that gem: railsconfig/config#180

As such, this is only a temporary fix until the railsconfig/config#178 ticket is fixed and a new version of the `config` gem is released.   Once that occurs, this monkeypatch should be deleted.

I've tested this locally, and with this monkey-patch in place, setting `SETTINGS__MULTITENANCY__ADMIN_ONLY_TENANT_CREATION=false` as an environment variable now works as expected.

@samvera/hyrax-code-reviewers
