### PR TITLE
Fix invalid foreign key error in languages importer

### DIFF
--- a/db/migrate/20171208100918_change_foreign_key_for_qa_local_authority_entries.rb
+++ b/db/migrate/20171208100918_change_foreign_key_for_qa_local_authority_entries.rb
@@ -1,0 +1,6 @@
+class ChangeForeignKeyForQaLocalAuthorityEntries < ActiveRecord::Migration[5.1]
+  def change
+    remove_foreign_key :qa_local_authority_entries, :local_authorities
+    add_foreign_key :qa_local_authority_entries, :qa_local_authorities, column: :local_authority_id,  index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170926184254) do
+ActiveRecord::Schema.define(version: 20171208100918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -620,6 +620,6 @@ ActiveRecord::Schema.define(version: 20170926184254) do
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
   add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
   add_foreign_key "permission_template_accesses", "permission_templates"
-  add_foreign_key "qa_local_authority_entries", "local_authorities"
+  add_foreign_key "qa_local_authority_entries", "qa_local_authorities", column: "local_authority_id"
   add_foreign_key "uploaded_files", "users"
 end


### PR DESCRIPTION
See Hyrax [issue 1034](https://github.com/samvera/hyrax/issues/1034)

This is caused by an incorrect foreign key. This PR adds a new migration to remove the incorrect foreign key and add the correct one.

Tested by running `hyrax:controlled_vocabularies:language` which now successfully imports lexvo.