### PR TITLE
Fix error loading Fits MediaInfo dependency [Docker]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM ruby:2.3.1
 RUN apt-get update -qq && \
     apt-get install -y build-essential libpq-dev nodejs libreoffice imagemagick unzip ghostscript && \
     rm -rf /var/lib/apt/lists/*
+# If changes are made to fits version or location,
+# amend `LD_LIBRARY_PATH` in docker-compose.yml accordingly.
 RUN mkdir -p /opt/fits && \
     curl -fSL -o /opt/fits-1.0.5.zip http://projects.iq.harvard.edu/files/fits/files/fits-1.0.5.zip && \
     cd /opt && unzip fits-1.0.5.zip && chmod +X fits-1.0.5/fits.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,8 @@ services:
       - RAILS_LOG_TO_STDOUT=true
       - SECRET_KEY_BASE=asdf
       - RAILS_CACHE_STORE_URL=memcache
+# version and location of fits are set in Dockerfile:
+      - LD_LIBRARY_PATH=/opt/fits-1.0.5/tools/mediainfo/linux
     volumes:
       - app:/data/tmp/uploads
     networks:


### PR DESCRIPTION
Fixes #1274. referenced in #1301

```
RuntimeError: Unable to execute command "/opt/fits-1.0.5/fits.sh -i "/data/tmp/uploads/[etc]""
workers_1         | Exception in thread "main" edu.harvard.hul.ois.fits.exceptions.FitsToolException: 
Error loading native library for MediaInfo please check that fits_home is properly set
```

Change proposed in this pull request:
* Add an environment variable pointing to FITS in `docker-compose.yml`

(CLA coming soon)
@samvera/hyrax-code-reviewers
