### PR TITLE
Use shields.io to fix waffle badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/samvera-labs/hyku.svg)](https://travis-ci.org/samvera-labs/hyku)
 [![Coverage Status](https://coveralls.io/repos/samvera-labs/hyku/badge.svg?branch=master&service=github)](https://coveralls.io/github/samvera-labs/hyku?branch=master)
-[![Stories in Ready](https://badge.waffle.io/samvera-labs/hyku.png?label=ready&title=Ready)](https://waffle.io/samvera-labs/hyku)
+[![Stories in Ready](https://img.shields.io/waffle/label/samvera-labs/hyku/ready.svg)](https://waffle.io/samvera-labs/hyku)
 
 # Hyku, the Hydra-in-a-Box Repository Application
 


### PR DESCRIPTION
This fixes the waffle badge.

This is a duplicate of https://github.com/samvera-labs/hyku/pull/1522 but made from a branch instead of a fork to test whether this build will pass or whether the aws tests will fail. These are the tests in question: https://github.com/samvera-labs/hyku/blob/master/spec/models/uploaded_file_spec.rb#L39-L108

@samvera/hyrax-code-reviewers
