### PR TITLE
Creative Commons License in main fields when adding a new work

### DIFF
--- a/app/forms/hyrax/form_terms.rb
+++ b/app/forms/hyrax/form_terms.rb
@@ -1,0 +1,11 @@
+module Hyrax
+  module FormTerms
+    include Hyrax::Forms
+    # overrides Hyrax::Forms::WorkForm
+    # to display 'license' in the 'base-terms' div on the user dashboard "Add New Work" description
+    # by getting iterated over in hyrax/app/views/hyrax/base/_form_metadata.html.erb
+    def primary_terms
+      super + [:license]
+    end
+  end
+end

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -2,6 +2,7 @@
 #  `rails generate curation_concerns:work GenericWork`
 module Hyrax
   class GenericWorkForm < Hyrax::Forms::WorkForm
+    include Hyrax::FormTerms
     self.model_class = ::GenericWork
     include HydraEditor::Form::Permissions
     self.terms += %i[resource_type rendering_ids]

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -2,6 +2,7 @@
 #  `rails generate hyrax:work Image`
 module Hyrax
   class ImageForm < Hyrax::Forms::WorkForm
+    include Hyrax::FormTerms
     self.model_class = ::Image
     self.terms += %i[resource_type extent rendering_ids]
 

--- a/spec/forms/hyrax/generic_work_form_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_spec.rb
@@ -20,4 +20,6 @@ RSpec.describe Hyrax::GenericWorkForm do
       expect(subject['rendering_ids']).to eq [file_set.id]
     end
   end
+
+  include_examples("work_form")
 end

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -23,4 +23,6 @@ RSpec.describe Hyrax::ImageForm do
       expect(subject['extent']).to eq ['extent']
     end
   end
+
+  include_examples("work_form")
 end

--- a/spec/support/shared_examples_spec.rb
+++ b/spec/support/shared_examples_spec.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples "work_form" do
+  describe ".primary_terms" do
+    it 'includes the license field' do
+      expect(form.primary_terms).to include(:license)
+    end
+  end
+end


### PR DESCRIPTION
Changes proposed in this pull request:

Display the Creative Commons "License" menu in the main fields when adding a new work, by adding `license` to `primary_terms`

![screen shot 2018-04-20 at 15 49 11](https://user-images.githubusercontent.com/26539307/39058031-a67cc5cc-44b2-11e8-853f-ddede29f8dac.png)

We implemented this change in [our fork of Hyku](https://github.com/ubiquitypress/hyku).
@samvera/hyrax-code-reviewers
