### PR TITLE
Add username field on sign up

### DIFF
--- a/app/controllers/hyku/registrations_controller.rb
+++ b/app/controllers/hyku/registrations_controller.rb
@@ -1,5 +1,6 @@
 module Hyku
   class RegistrationsController < Devise::RegistrationsController
+    before_action :configure_permitted_parameters
     def new
       return super if Settings.devise.account_signup
       redirect_to root_path, alert: t(:'hyku.account.signup_disabled')
@@ -9,5 +10,11 @@ module Hyku
       return super if Settings.devise.account_signup
       redirect_to root_path, alert: t(:'hyku.account.signup_disabled')
     end
+
+    private
+
+      def configure_permitted_parameters
+        devise_parameter_sanitizer.permit(:sign_up, keys: [:display_name])
+      end
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,6 +5,7 @@
         <%= f.error_notification %>
 
         <div class="form-inputs">
+            <%= f.input :display_name, required: true, wrapper: :inline %>
             <%= f.input :email, required: true, autofocus: true, wrapper: :inline %>
             <%= f.input :password, required: true, wrapper: :inline %>
             <%= f.input :password_confirmation, required: true, wrapper: :inline %>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -35,6 +35,7 @@ en:
         per: 'Show'
       user:
         email: 'Email address'
+        display_name: 'Your Name'  # need to add this to other languages
     #   defaults:
     #     password: 'Password'
     #   user:


### PR DESCRIPTION
Changes proposed in this pull request:

Add name field on sign up in order to prepopulate the contact form with user name instead of an email address.

![screen shot 2018-04-23 at 12 55 07](https://user-images.githubusercontent.com/26539307/39125270-4c1aecc6-46f6-11e8-819d-3c4cafa9f75d.png)

![screen shot 2018-04-23 at 12 57 47](https://user-images.githubusercontent.com/26539307/39125278-50fc7944-46f6-11e8-9548-64dc9f12b5d8.png)

We implemented this change in [our fork of Hyku.](https://github.com/ubiquitypress/hyku)
@samvera/hyrax-code-reviewers
