### PR TITLE
Hook up supported metadata tags

### DIFF
--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,4 +1,5 @@
 <% provide :page_title, @presenter.page_title %>
+<%= render 'shared/citations' %>
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">
   <div class="col-xs-12">
     <header>


### PR DESCRIPTION
This already exists in [Hyrax](https://github.com/samvera/hyrax/blob/ca0766b3cc1b83859ce1b08d7cafbda18be07c84/app/views/hyrax/base/show.html.erb#L3)

before change:
![without_meta](https://user-images.githubusercontent.com/26539307/40313755-5f4522b6-5d0e-11e8-8870-9608f828073a.png)
The change proposed populates the metadata tags drafted [here](https://github.com/samvera/hyrax/blob/ca0766b3cc1b83859ce1b08d7cafbda18be07c84/app/views/shared/_citations.html.erb).
@samvera/hyrax-code-reviewers
