### PR TITLE
Add DOI and ISBNs citations tags

### DIFF
--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -35,7 +35,31 @@ module Hyku
       metadata
     end
 
+    # assumes there can only be one doi
+    def doi
+      doi_regex = %r{10.\d{4,9}\/[-._;()\/:A-Z0-9]+}i
+      doi = extract_from_identifier(doi_regex)
+      doi.join unless doi.nil?
+    end
+
+    # unlike doi, there can be multiple isbns
+    def isbns
+      isbn_regex = /(?:ISBN[- ]*13|ISBN[- ]*10|)\s*
+                   ((?:(?:9[\s-]*7[\s-]*[89])?[ -]?(?:[0-9][ -]*){9})[ -]*(?:[0-9xX]))/x
+      isbns = extract_from_identifier(isbn_regex)
+      isbns.flatten unless doi.nil?
+    end
+
     private
+
+      def extract_from_identifier(rgx)
+        unless solr_document['identifier_tesim'].nil?
+          ref = solr_document['identifier_tesim'].map do |str|
+            str.scan(rgx)
+          end
+        end
+        ref
+      end
 
       def manifest_helper
         @manifest_helper ||= ManifestHelper.new(request.base_url)

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -39,21 +39,22 @@ module Hyku
     def doi
       doi_regex = %r{10.\d{4,9}\/[-._;()\/:A-Z0-9]+}i
       doi = extract_from_identifier(doi_regex)
-      doi.join unless doi.nil?
+      doi.join if doi
     end
 
     # unlike doi, there can be multiple isbns
     def isbns
-      isbn_regex = /(?:ISBN[- ]*13|ISBN[- ]*10|)\s*
-                   ((?:(?:9[\s-]*7[\s-]*[89])?[ -]?(?:[0-9][ -]*){9})[ -]*(?:[0-9xX]))/x
+      isbn_regex = /(?:ISBN[- ]*13|ISBN[- ]*10|)\s*(
+                    ((?:(?:9[\s-]*7[\s-]*[89])?[ -]?((?:[0-9][ -]*){9})(?!$|[xX0-9]))[ -]*(?:[0-9xX]))|
+                    ((?:[0-9][ -]*){13}))/x
       isbns = extract_from_identifier(isbn_regex)
-      isbns.flatten unless doi.nil?
+      isbns.flatten if isbns
     end
 
     private
 
       def extract_from_identifier(rgx)
-        unless solr_document['identifier_tesim'].nil?
+        if solr_document['identifier_tesim'].present?
           ref = solr_document['identifier_tesim'].map do |str|
             str.scan(rgx)
           end

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,4 +1,5 @@
 <% provide :page_title, @presenter.page_title %>
+<%= render './shared/additional_citations' %>
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">
   <div class="col-xs-12">
     <header>

--- a/app/views/shared/_additional_citations.html.erb
+++ b/app/views/shared/_additional_citations.html.erb
@@ -1,0 +1,10 @@
+<% content_for(:gscholar_meta) do %>
+  <% unless @presenter.doi.blank? %>
+    <meta name="citation_doi" content="<%= @presenter.doi %>"/>
+  <% end %>
+  <% unless @presenter.isbns.blank? %>
+    <% @presenter.isbns.each do |isbn| %>
+      <meta name="citation_isbn" content="<%= isbn %>"/>
+    <% end %>
+  <% end %>
+<% end %>

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -6,6 +6,11 @@ FactoryGirl.define do
 
     title ["Test title"]
 
+    identifier %w[
+      ISBN:978-83-7659-303-6 978-3-540-49698-4 9790879392788
+      doi:10.1038/nphys1170 3-921099-34-X 3-540-49698-x 0-19-852663-6
+    ]
+
     factory :work_with_one_file do
       before(:create) do |work, evaluator|
         work.ordered_members << FactoryGirl.create(:file_set,

--- a/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
+++ b/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
@@ -58,27 +58,80 @@ RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
     end
   end
 
-  context "when the work has identifier" do
-    let(:document) do
-      { "identifier_tesim" => %w[
-        ISBN:978-83-7659-303-6 978-3-540-49698-4 9790879392788
-        doi:10.1038/nphys1170 3-921099-34-X 3-540-49698-x 0-19-852663-6
-      ] }
-    end
-
+  context "when the work has valid doi and isbns" do
+    # the values are set in generic_works factory
     describe "#doi" do
       it "extracts the DOI from the identifiers" do
-        # puts solr_document.inspect
-        expect(presenter.doi).to eq("10.1038/nphys1170")
+        expect(presenter.doi).to eq('10.1038/nphys1170')
       end
     end
 
     describe "#isbns" do
       it "extracts ISBNs from the identifiers" do
-        expect(presenter.isbns).to eq(%w[
-                                        978-83-7659-303-6 978-3-540-49698-4 9790879392788
-                                        3-921099-34-X 3-540-49698-x 0-19-852663-6
-                                      ])
+        expect(presenter.isbns)
+          .to include('978-83-7659-303-6', '978-3-540-49698-4', '9790879392788',
+                      '3-921099-34-X', '3-540-49698-x', '0-19-852663-6')
+      end
+    end
+  end
+
+  context "when the identifier is nil" do
+    let(:document) do
+      { "identifier_tesim" => nil }
+    end
+
+    describe "#doi" do
+      it "is nil" do
+        expect(presenter.doi).to be_nil
+      end
+    end
+
+    describe "#isbns" do
+      it "is nil" do
+        expect(presenter.isbns).to be_nil
+      end
+    end
+  end
+
+  context "when the work has a doi only" do
+    let(:document) do
+      { "identifier_tesim" => ['10.1038/nphys1170'] }
+    end
+
+    describe "#isbns" do
+      it "is empty" do
+        expect(presenter.isbns).to be_empty
+      end
+    end
+  end
+
+  context "when the work has isbn(s) only" do
+    let(:document) do
+      { "identifier_tesim" => ['ISBN:978-83-7659-303-6'] }
+    end
+
+    describe "#doi" do
+      it "is empty" do
+        expect(presenter.doi).to be_empty
+      end
+    end
+  end
+
+  context "when the work's identifiers are not valid doi or isbns" do
+    # FOR CONSIDERATION: validate format when a user adds an identifier?
+    let(:document) do
+      { "identifier_tesim" => %w[3207/2959859860 svnklvw24 0470841559.ch1] }
+    end
+
+    describe "#doi" do
+      it "is empty" do
+        expect(presenter.doi).to be_empty
+      end
+    end
+
+    describe "#isbns" do
+      it "is empty" do
+        expect(presenter.isbns).to be_empty
       end
     end
   end

--- a/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
+++ b/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
@@ -57,4 +57,29 @@ RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
       expect(subject[0]['value']).to include('Test title', 'Another test title')
     end
   end
+
+  context "when the work has identifier" do
+    let(:document) do
+      { "identifier_tesim" => %w[
+        ISBN:978-83-7659-303-6 978-3-540-49698-4 9790879392788
+        doi:10.1038/nphys1170 3-921099-34-X 3-540-49698-x 0-19-852663-6
+      ] }
+    end
+
+    describe "#doi" do
+      it "extracts the DOI from the identifiers" do
+        # puts solr_document.inspect
+        expect(presenter.doi).to eq("10.1038/nphys1170")
+      end
+    end
+
+    describe "#isbns" do
+      it "extracts ISBNs from the identifiers" do
+        expect(presenter.isbns).to eq(%w[
+                                        978-83-7659-303-6 978-3-540-49698-4 9790879392788
+                                        3-921099-34-X 3-540-49698-x 0-19-852663-6
+                                      ])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This builds on PRs #1527 and #1528 ; adding logic to have `doi` and `isbn` citation tags for Google Scholar indexing:
![doi-isbn](https://user-images.githubusercontent.com/26539307/40490634-f6089c8a-5f63-11e8-8e81-95ac23884fc2.png)

@samvera/hyrax-code-reviewers
