### PR TITLE
solr_wrapper update, sha1 usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :development, :test do
   gem 'simplecov', require: false
 
   gem 'fcrepo_wrapper', '~> 0.4'
-  gem 'solr_wrapper', '~> 1.0'
+  gem 'solr_wrapper', '~> 2.0'
 
   gem 'rubocop', '~> 0.50', '<= 0.52.1'
   gem 'rubocop-rspec', '~> 1.22', '<= 1.22.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -713,7 +713,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    retriable (3.1.1)
+    retriable (3.1.2)
     riiif (1.4.4)
       railties (>= 4.2, < 6)
     rolify (5.1.0)
@@ -808,7 +808,7 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (4.6.0)
-    solr_wrapper (1.2.0)
+    solr_wrapper (2.0.0)
       faraday
       retriable
       ruby-progressbar
@@ -953,7 +953,7 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq
   simplecov
-  solr_wrapper (~> 1.0)
+  solr_wrapper (~> 2.0)
   spring (~> 1.7)
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)


### PR DESCRIPTION
Fixes #1535

fixes the fact that apache no longer creates md5sums for releases

This and a new config options appear to be the only things happening in the delta between solr_wrapper 1.2 and 2.0

@samvera/hyrax-code-reviewers