### PR TITLE
Fixing the s3 specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,7 +56,7 @@ RSpec.configure do |config|
 
   # only run aws tests from CI (or w/ `--tag aws`) and only run it on the main repo, since that
   # is where the valid aws keys live
-  config.filter_run_excluding(aws: true) unless ENV['CI'] && ENV['TRAVIS_REPO_SLUG'].match('samvera-labs/hyku')
+  config.filter_run_excluding(aws: true) unless ENV['CI'] && ENV['TRAVIS_PULL_REQUEST_SLUG'].match('samvera-labs/hyku')
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,8 +54,9 @@ RSpec.configure do |config|
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
 
-  # only run aws tests from CI (or w/ `--tag aws`)
-  config.filter_run_excluding(aws: true) unless ENV['CI']
+  # only run aws tests from CI (or w/ `--tag aws`) and only run it on the main repo, since that
+  # is where the valid aws keys live
+  config.filter_run_excluding(aws: true) unless ENV['CI'] && ENV['TRAVIS_REPO_SLUG'].match('samvera-labs/hyku')
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend


### PR DESCRIPTION
Fixes #1524 

No longer run S3 related specs on non-samvera-labs repos. This will allow specs to pass on forks.

This is a first swing at getting Travis to not run the specs unless the code is in samvera-labs/hyku. Specs on forks will thus pass and the 4 failing S3 specs from forks will get run properly once code is merged.

Note - need to check that the specs in question are run after this is merged.

@samvera/hyrax-code-reviewers
