### PR TITLE
Fix s3 specs - part 2

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,8 +55,11 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   # only run aws tests from CI (or w/ `--tag aws`) and only run it on the main repo, since that
-  # is where the valid aws keys live
-  config.filter_run_excluding(aws: true) unless ENV['CI'] && ENV['TRAVIS_PULL_REQUEST_SLUG'].match('samvera-labs/hyku')
+  # is where the valid aws keys live. TRAVIS_PULL_REQUEST_SLUG is "" when the job is a push job
+  unless ENV['CI'] &&
+         (ENV['TRAVIS_PULL_REQUEST_SLUG'].match('samvera-labs/hyku') || ENV['TRAVIS_PULL_REQUEST_SLUG'].blank?)
+    config.filter_run_excluding(aws: true)
+  end
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend


### PR DESCRIPTION
As hypothesized, the specs are not running in master any more.  That appears to be because TRAVIS_PULL_REQUEST_SLUG if you are not talking about a pull request. This should work in both cases now.