### PR TITLE
Included render file

### DIFF
--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -37,18 +37,17 @@ module Hyku
 
     # assumes there can only be one doi
     def doi
-      doi_regex = %r{10.\d{4,9}\/[-._;()\/:A-Z0-9]+}i
+      doi_regex = %r{10\.\d{4,9}\/[-._;()\/:A-Z0-9]+}i
       doi = extract_from_identifier(doi_regex)
       doi.join if doi
     end
 
     # unlike doi, there can be multiple isbns
     def isbns
-      isbn_regex = /(?:ISBN[- ]*13|ISBN[- ]*10|)\s*(
-                    ((?:(?:9[\s-]*7[\s-]*[89])?[ -]?((?:[0-9][ -]*){9})(?!$|[xX0-9]))[ -]*(?:[0-9xX]))|
-                    ((?:[0-9][ -]*){13}))/x
+      isbn_regex = /((?:ISBN[- ]*13|ISBN[- ]*10|)\s*97[89][ -]*\d{1,5}[ -]*\d{1,7}[ -]*\d{1,6}[ -]*\d)|
+                    ((?:[0-9][-]*){9}[ -]*[xX])|(^(?:[0-9][-]*){10}$)/x
       isbns = extract_from_identifier(isbn_regex)
-      isbns.flatten if isbns
+      isbns.flatten.compact if isbns
     end
 
     private

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,5 +1,6 @@
 <% provide :page_title, @presenter.page_title %>
 <%= render 'shared/citations' %>
+<%= render './shared/additional_citations' %>
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">
   <div class="col-xs-12">
     <header>

--- a/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
+++ b/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
     describe "#isbns" do
       it "extracts ISBNs from the identifiers" do
         expect(presenter.isbns)
-          .to include('978-83-7659-303-6', '978-3-540-49698-4', '9790879392788',
-                      '3-921099-34-X', '3-540-49698-x', '0-19-852663-6')
+          .to match_array(%w[978-83-7659-303-6 978-3-540-49698-4 9790879392788
+                             3-921099-34-X 3-540-49698-x 0-19-852663-6])
       end
     end
   end


### PR DESCRIPTION
As discussed in #1531  @orangewolf 

I also modified the ISBN regex: when I double-checked the feature in browser there was some wrongly identified isbn argh! I've modified the test so it would catch the bug: `match_array` instead of `include`.
