### PR TITLE
Harmonize dashboard with current Hyrax code

### DIFF
--- a/app/views/hyrax/dashboard/_sidebar.html.erb
+++ b/app/views/hyrax/dashboard/_sidebar.html.erb
@@ -1,139 +1,21 @@
 <% menu = Hyku::MenuPresenter.new(self) %>
 <div class="sidebar-toggle"><span class="fa fa-chevron-circle-right"></span></div>
-<ul class="admin-sidebar nav nav-pills nav-stacked">
-  <li>
-    <div class="profile">
-      <div class="profile-image">
-        <%= image_tag current_user.avatar.url(:thumb), width: 100 if current_user.avatar.present? %>
-      </div>
-      <div class="profile-data">
-        <div class="profile-data-name"><%= current_user.name %></div>
-      </div>
-    </div>
-  </li>
-
-  <li class="h5"><%= t('hyrax.admin.sidebar.activity') %></li>
-  <li>
-    <%= menu.collapsable_section t('hyrax.admin.sidebar.repository_activity'),
-                                 icon_class: "fa fa-line-chart",
-                                 id: 'collapseRepositoryActivity',
-                                 open: menu.repository_activity_section? do %>
-      <%= menu.nav_link(hyrax.dashboard_path) do %>
-        <span class="fa fa-dashboard"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.activity_summary') %></span>
-      <% end %>
-      <% if menu.show_admin_menu_items? %>
-        <%= menu.nav_link(main_app.status_path) do %>
-          <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.system_status') %></span>
-        <% end %>
-      <% end %>
-    <% end %>
-  </li>
-
-  <li>
-    <%= menu.collapsable_section t('hyrax.admin.sidebar.user_activity'),
-                                 icon_class: "fa fa-line-chart",
-                                 id: 'collapseUserActivity',
-                                 open: menu.user_activity_section? do %>
-      <%= menu.nav_link(hyrax.dashboard_profile_path(current_user)) do %>
-        <span class="fa fa-user"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.profile') %></span>
-      <% end %>
-      <%= menu.nav_link(hyrax.notifications_path) do %>
-        <span class="fa fa-bell"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.notifications') %></span>
-      <% end %>
-      <%= menu.nav_link(hyrax.transfers_path) do %>
-        <span class="fa fa-arrows-h"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.transfers') %></span>
-      <% end %>
-    <% end %>
-  </li>
-
-  <li class="h5"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
-  <% if can? :create, AdminSet %>
-    <%= menu.nav_link(hyrax.admin_admin_sets_path) do %>
-      <span class="fa fa-sitemap"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.admin_sets') %></span>
-    <% end %>
-  <% end %>
-
-  <%= menu.nav_link(hyrax.my_collections_path,
-                    also_active_for: hyrax.dashboard_collections_path) do %>
-    <span class="fa fa-folder-open"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
-  <% end %>
-
-  <%= menu.nav_link(hyrax.my_works_path,
-                    also_active_for: hyrax.dashboard_works_path) do %>
-    <span class="fa fa-file"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
-  <% end %>
-
-  <% if menu.show_admin_menu_items? %>
-    <li class="h5"><%= t('hyrax.admin.sidebar.tasks') %></li>
-    <% if Site.account && can?(:manage, Site.account) %>
-      <%= menu.nav_link(main_app.edit_admin_account_path) do %>
-          Account
-      <% end %>
-    <% end %>
-
-    <%= menu.nav_link(hyrax.admin_workflows_path) do %>
-      <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_review') %></span>
-    <% end %>
-
-    <%= menu.nav_link(hyrax.admin_stats_path) do %>
-      <span class="fa fa-bar-chart"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.statistics') %></span>
-    <% end %>
-  <% end  # end of tasks block %>
-
-  <% if menu.show_configuration? %>
-    <li class="h5"><%= t('hyrax.admin.sidebar.configuration') %></li>
-    <% if can? :manage, Site %>
-      <li>
-        <%= menu.collapsable_section t('hyrax.admin.sidebar.settings'),
-                                     icon_class: "fa fa-cog",
-                                     id: 'collapseSettings',
-                                     open: menu.settings_section? do %>
-          <%= menu.nav_link(main_app.edit_site_labels_path) do %>
-            <span class="fa fa-institution"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.labels') %></span>
-          <% end %>
-           <% if can?(:update, :appearance) %>
-            <%= menu.nav_link(hyrax.admin_appearance_path) do %>
-              <span class="fa fa-paint-brush"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.appearance') %></span>
-            <% end %>
-          <% end %>
-          <%= menu.nav_link(hyrax.edit_pages_path) do %>
-            <span class="fa fa-file-text-o"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.pages') %></span>
-          <% end %>
-          <%= menu.nav_link(hyrax.edit_content_blocks_path) do %>
-            <span class="fa fa-square-o"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.content_blocks') %></span>
-          <% end %>
-          <%= menu.nav_link(hyrax.admin_features_path) do %>
-            <span class="fa fa-wrench"></span> <span class="sidebar-action-text">Technical</span>
-          <% end %>
-        <% end # end settings section %>
-      </li>
-    <% end %>
-
-    <% if can? :create, Sipity::WorkflowResponsibility %>
-      <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
-        <span class="fa fa-users"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>
-      <% end %>
-    <% end %>
-
-    <% if can?(:manage, User) || can?(:manage, Hyku::Group) %>
+<nav>
+  <ul class="nav nav-pills nav-stacked">
     <li>
-      <%= menu.collapsable_section t('hyrax.admin.sidebar.roles_and_permissions'),
-                                   icon_class: "fa fa-users",
-                                   id: 'collapseRoles',
-                                   open: menu.roles_and_permissions_section? do %>
-        <% if can? :manage, Hyku::Group %>
-          <%= menu.nav_link(main_app.admin_groups_path) do %>
-            <span class="fa fa-users"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.manage_groups') %></span>
-          <% end %>
-        <% end %>
-
-        <% if can? :manage, User %>
-          <%= menu.nav_link(hyrax.admin_users_path) do %>
-            <span class="fa fa-user"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.manage_users') %></span>
-          <% end %>
-        <% end %>
-      <% end %>
+      <div class="profile">
+        <div class="profile-image">
+          <%= image_tag current_user.avatar.url(:thumb), width: 100 if current_user.avatar.present? %>
+        </div>
+        <div class="profile-data">
+          <div class="profile-data-name"><%= current_user.name %></div>
+        </div>
+      </div>
     </li>
-    <% end %>
-  <% end # end of configuration block %>
-</ul>
+
+    <%= render 'hyrax/dashboard/sidebar/activity', menu: menu %>
+    <%= render 'hyrax/dashboard/sidebar/repository_content', menu: menu %>
+    <%= render 'hyrax/dashboard/sidebar/tasks', menu: menu %>
+    <%= render 'hyrax/dashboard/sidebar/configuration', menu: menu %>
+  </ul>
+</nav>

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -1,0 +1,49 @@
+  <li class="h5"><%= t('hyrax.admin.sidebar.activity') %></li>
+  
+  <li>
+    <%= menu.collapsable_section t('hyrax.admin.sidebar.repository_activity'),
+                                 icon_class: "fa fa-line-chart",
+                                 id: 'collapseRepositoryActivity',
+                                 open: menu.repository_activity_section? do %>
+      <%= menu.nav_link(hyrax.dashboard_path) do %>
+        <span class="fa fa-dashboard"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.activity_summary') %></span>
+      <% end %>
+      <% if menu.show_admin_menu_items? %>
+        <%= menu.nav_link(main_app.status_path) do %>
+          <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.system_status') %></span>
+        <% end %>
+      <% end %>
+    <% end %>
+  </li>
+
+  <li>
+    <%= menu.collapsable_section t('hyrax.admin.sidebar.user_activity'),
+                                 icon_class: "fa fa-line-chart",
+                                 id: 'collapseUserActivity',
+                                 open: menu.user_activity_section? do %>
+      <%= menu.nav_link(hyrax.dashboard_profile_path(current_user),
+                        also_active_for: hyrax.edit_dashboard_profile_path(current_user)) do %>
+        <span class="fa fa-id-card" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.profile') %></span>
+      <% end %>
+
+      <%= menu.nav_link(hyrax.notifications_path) do %>
+        <span class="fa fa-bell" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.notifications') %></span>
+      <% end %>
+
+      <%= menu.nav_link(hyrax.transfers_path) do %>
+        <span class="fa fa-arrows-h" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.transfers') %></span>
+      <% end %>
+
+      <% if Flipflop.proxy_deposit? %>
+        <%= menu.nav_link(hyrax.depositors_path) do %>
+          <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.dashboard.manage_proxies') %></span>
+        <% end %>
+      <% end %>
+    <% end %>
+  </li>
+
+  <% if can? :read, :admin_dashboard %>
+    <%= menu.nav_link(hyrax.admin_stats_path) do %>
+      <span class="fa fa-bar-chart" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.statistics') %></span>
+    <% end %>
+  <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
@@ -1,0 +1,41 @@
+  <% if menu.show_configuration? %>
+    <li class="h5"><%= t('hyrax.admin.sidebar.configuration') %></li>
+    <% if can? :manage, Site %>
+        <li>
+          <%= menu.collapsable_section t('hyrax.admin.sidebar.settings'),
+                     icon_class: "fa fa-cog",
+                     id: 'collapseSettings',
+                     open: menu.settings_section? do %>
+      <%= menu.nav_link(main_app.edit_site_labels_path) do %>
+          <span class="fa fa-institution"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.labels') %></span>
+      <% end %>
+      <% if can?(:update, :appearance) %>
+        <%= menu.nav_link(hyrax.admin_appearance_path) do %>
+          <span class="fa fa-paint-brush" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.appearance') %></span>
+        <% end %>
+      <% end %>
+      <% if can?(:manage, :collection_types) %>
+        <%= menu.nav_link(hyrax.admin_collection_types_path) do %>
+          <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collection_types') %></span>
+        <% end %>
+      <% end %>
+      <% if can?(:manage, Hyrax::Feature) %>
+        <%= menu.nav_link(hyrax.edit_pages_path) do %>
+          <span class="fa fa-file-text-o" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.pages') %></span>
+        <% end %>
+        <%= menu.nav_link(hyrax.edit_content_blocks_path) do %>
+          <span class="fa fa-square-o" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.content_blocks') %></span>
+        <% end %>
+        <%= menu.nav_link(hyrax.admin_features_path) do %>
+          <span class="fa fa-wrench" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.technical') %></span>
+        <% end %>
+      <% end %>
+          <% end %>
+        </li>
+    <% end %>
+    <% if can?(:manage, Sipity::WorkflowResponsibility) %>
+      <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
+        <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>
+      <% end %>
+    <% end # end of configuration block %>
+  <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -1,0 +1,28 @@
+  <% if can? :review, :submissions %>
+    <li class="h5"><%= t('hyrax.admin.sidebar.tasks') %></li>
+    <%= menu.nav_link(hyrax.admin_workflows_path) do %>
+      <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_review') %></span>
+    <% end %>
+  <% end %>
+
+  <% if can? :manage, User %>
+    <%= menu.nav_link(hyrax.admin_users_path) do %>
+      <span class="fa fa-user" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
+    <% end %>
+  <% end %>
+  
+  <% if can? :manage, Hyku::Group %>
+          <%= menu.nav_link(main_app.admin_groups_path) do %>
+            <span class="fa fa-users"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.manage_groups') %></span>
+          <% end %>
+        <% end %>
+
+  <% if can? :read, :admin_dashboard %>
+    <%= menu.nav_link(hyrax.embargoes_path) do %>
+      <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.embargoes.index.manage_embargoes') %></span>
+    <% end %>
+
+    <%= menu.nav_link(hyrax.leases_path) do %>
+      <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.leases.index.manage_leases') %></span>
+    <% end %>
+  <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -108,15 +108,9 @@ de:
       sidebar:
         accounts: Konten
         activity_summary: Aktivitätsübersicht
-        content_blocks: Inhaltsblöcke
         labels: Etiketten
-        manage_groups: Gruppen verwalten
-        manage_roles_and_permissions: Rollen und Berechtigungen definieren
-        manage_users: Benutzer verwalten
-        repository_activity: Repository-Aktivität
-        roles_and_permissions: Benutzer und Gruppen
+        manage_groups: Gruppen Verwalten
         system_status: Systemstatus
-        technical: Technisch
       users:
         destroy:
           confirmation: Möchten Sie den Benutzer "%{user}" wirklich löschen? Diese Aktion ist irreversibel.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,16 +106,10 @@ en:
             colors: Colors
       sidebar:
         accounts: Accounts
-        activity_summary: Activity summary
-        content_blocks: Content Blocks
+        activity_summary: Activity Summary
         labels: Labels
-        manage_groups: Manage groups
-        manage_roles_and_permissions: Define roles and permissions
-        manage_users: Manage users
-        repository_activity: Repository activity
-        roles_and_permissions: Users and groups
-        system_status: System status
-        technical: Technical
+        manage_groups: Manage Groups
+        system_status: System Status
       users:
         destroy:
           confirmation: Are you sure you wish to delete the user "%{user}"? This action is irreversible.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -108,15 +108,9 @@ es:
       sidebar:
         accounts: Cuentas
         activity_summary: Resumen de la actividad
-        content_blocks: Bloques de contenido
         labels: Etiquetas
-        manage_groups: Administrar grupos
-        manage_roles_and_permissions: Defina roles y permisos
-        manage_users: Administrar usuarios
-        repository_activity: Actividad de repositorio
-        roles_and_permissions: Usarios y grupos
+        manage_groups: Administrar Grupos
         system_status: Estado del sistema
-        technical: Técnico
       users:
         destroy:
           confirmation: ¿Estás seguro de que deseas eliminar el usuario "%{user}"? Esta acción es irreversible.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -108,15 +108,9 @@ it:
       sidebar:
         accounts: conti
         activity_summary: Riepilogo attività
-        content_blocks: Blocchi di contenuti
         labels: etichette
         manage_groups: Gestisci gruppi
-        manage_roles_and_permissions: Definire ruoli e autorizzazioni
-        manage_users: Gestire gli utenti
-        repository_activity: Attività di repository
-        roles_and_permissions: Utenti e gruppi
         system_status: Stato del sistema
-        technical: Tecnico
       users:
         destroy:
           confirmation: Sei sicuro di voler cancellare l'utente "%{user}"? Questa azione è irreversibile.

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -108,15 +108,9 @@ pt-BR:
       sidebar:
         accounts: Contas
         activity_summary: Resumo da atividade
-        content_blocks: Blocos de conteúdo
         labels: Etiquetas
         manage_groups: Gerenciar grupos
-        manage_roles_and_permissions: Definir funções e permissões
-        manage_users: Gerenciar usuários
-        repository_activity: Atividade do depósito
-        roles_and_permissions: Usuários e grupos
         system_status: Status do sistema
-        technical: Técnico
       users:
         destroy:
           confirmation: Tem certeza de que deseja excluir o usuário "%{user}"? Esta ação é irreversível.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -108,15 +108,9 @@ zh:
       sidebar:
         accounts: 帐号
         activity_summary: 活动摘要
-        content_blocks: 内容块
         labels: 标签
         manage_groups: 管理组
-        manage_roles_and_permissions: 定义角色和权限
-        manage_users: 管理用户
-        repository_activity: 存储库活动
-        roles_and_permissions: 用户和组
         system_status: 系统状态
-        technical: 技术
       users:
         destroy:
           confirmation: 您确定要删除用户“%{user}”吗？这一行动是不可逆转的。

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -10,16 +10,17 @@ RSpec.describe 'Admin Dashboard', type: :feature do
     it 'shows the admin page' do
       visit Hyrax::Engine.routes.url_helpers.dashboard_path
       within '.sidebar' do
-        expect(page).to have_link('Activity summary')
+        expect(page).to have_link('Activity Summary')
+        expect(page).to have_link('System Status')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Notifications')
         expect(page).to have_link('Transfers')
         expect(page).to have_link('Labels')
         expect(page).to have_link('Appearance')
         expect(page).to have_link('Content Blocks')
-        expect(page).to have_link('Technical')
-        expect(page).to have_link('Manage groups')
-        expect(page).to have_link('Manage users')
+        expect(page).to have_link('Features')
+        expect(page).to have_link('Manage Groups')
+        expect(page).to have_link('Manage Users')
         expect(page).to have_link('Reports')
       end
     end


### PR DESCRIPTION
This PR adds the Collection Types tab into the admin dashboard, and removes Admin Sets (now part of Collections). In addition, I've harmonized the dashboard with current Hyrax.

List of changes:

* split code into partials to mirror Hyrax
* add collection types to settings
* remove admin sets (now part of collections)
* removed 'users and groups', moved manage users and manage groups to 'tasks'
* renamed Technical to Features
* removed unused labels from locales