### PR TITLE
Support pinging fedora endpoints with basic auth

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -805,7 +805,7 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (4.6.2)
-    solr_wrapper (2.0.0)
+    solr_wrapper (2.1.0)
       faraday
       retriable
       ruby-progressbar

--- a/app/models/fcrepo_endpoint.rb
+++ b/app/models/fcrepo_endpoint.rb
@@ -10,7 +10,9 @@ class FcrepoEndpoint < Endpoint
   end
 
   def ping
-    ActiveFedora::Fedora.instance.connection.head('/').response.success?
+    ActiveFedora::Fedora.instance.connection.head(
+      ActiveFedora::Fedora.instance.connection.connection.http.url_prefix.to_s
+    ).response.success?
   rescue StandardError
     false
   end

--- a/spec/models/fcrepo_endpoint_spec.rb
+++ b/spec/models/fcrepo_endpoint_spec.rb
@@ -13,13 +13,17 @@ RSpec.describe FcrepoEndpoint do
     let(:success_response) { double(response: double(success?: true)) }
 
     it 'checks if the service is up' do
-      allow(ActiveFedora::Fedora.instance.connection).to receive(:head).with('/').and_return(success_response)
+      allow(ActiveFedora::Fedora.instance.connection).to receive(:head).with(
+        ActiveFedora::Fedora.instance.connection.connection.http.url_prefix.to_s
+      ).and_return(success_response)
       expect(subject.ping).to be_truthy
     end
 
     it 'is false if the service is down' do
-      allow(ActiveFedora::Fedora.instance.connection).to receive(:head).with('/').and_raise(RuntimeError)
-      expect(subject.ping).to eq false
+      allow(ActiveFedora::Fedora.instance.connection).to receive(:head).with(
+        ActiveFedora::Fedora.instance.connection.connection.http.url_prefix.to_s
+      ).and_raise(RuntimeError)
+      expect(subject.ping).to be_falsey
     end
   end
 end


### PR DESCRIPTION
We have a live Hyku where fedora shows as `down` in the system status. I think this must be because it uses authentication. When I try the ping directly in the rails console, I get `Ldp::NotFound`.

The current `ping` method is:
```
def ping
    ActiveFedora::Fedora.instance.connection.head('/').response.success?
  rescue StandardError
    false
end
```

Changing it to the following works with our authenticated fedora:
```
def ping
    ActiveFedora::Fedora.instance.connection.head('/').response.success?
  rescue Ldp::NotFound
    ActiveFedora.fedora.connection.http.head.success?
  rescue StandardError
    false
end
```

Feedback welcome on this change. The tests still pass but they *don't* currently test for an authenticated fedora. Advice on how to approach that, or on how to do this in a better way, would be welcome.

@samvera/hyrax-code-reviewers
